### PR TITLE
Resource type can be selected as regular, documentation and historic.

### DIFF
--- a/ckanext/sse/dataset_schema.yaml
+++ b/ckanext/sse/dataset_schema.yaml
@@ -182,6 +182,8 @@ resource_fields:
       label: Regular
     - value: documentation
       label: Documentation
+    - value: historic
+      label: Historic
       
 - field_name: schema
   label: Schema fields

--- a/ckanext/sse/templates/package/snippets/resources_list.html
+++ b/ckanext/sse/templates/package/snippets/resources_list.html
@@ -1,0 +1,96 @@
+{#
+  Renders a list of resources with icons and view links.
+
+  resources - A list of resources (dicts) to render
+  pkg - A package dict that the resources belong to.
+
+  Example:
+
+  {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=pkg.resources %}
+
+  #}
+{% set resources_dict = {'regular': [], 'documentation': [], 'historic': []} %}
+
+{% for resource in resources %}
+  {% set resource_type = resource.get('resource_type') %}
+  {% if resource_type in resources_dict %}
+    {% do resources_dict[resource_type].append(resource) %}
+  {% else %}
+    {% do resources_dict['regular'].append(resource) %}
+  {% endif %}
+{% endfor %}
+
+{% set regular_resources = resources_dict['regular'] %}
+{% set documentation_resources = resources_dict['documentation'] %}
+{% set historic_resources = resources_dict['historic'] %}
+
+
+  <section id="dataset-resources" class="resources">
+    <h2>{{ _('Data and Resources') }}</h2>
+    {% block resource_list %}
+      {% if resources %}
+        {% set can_edit = can_edit or h.check_access('package_update', {'id':pkg.id }) %}
+        <ul class="{% block resource_list_class %}resource-list{% endblock %}">
+          {% block resource_list_inners %}
+            {% for resource in regular_resources %}
+              {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, can_edit=can_edit %}
+            {% endfor %}
+          {% endblock %}
+        </ul>
+      {% else %}
+        {% block resource_list_empty %}
+          {% if h.check_access('resource_create', {'package_id': pkg['id']}) %}
+            {% trans url=h.url_for(pkg.type ~ '_resource.new', id=pkg.name) %}
+            <p class="empty">This dataset has no data, <a href="{{ url }}">why not add some?</a></p>
+            {% endtrans %}
+          {% else %}
+            <p class="empty">{{ _('This dataset has no data') }}</p>
+          {% endif %}
+        {% endblock %}
+      {% endif %}
+    {% endblock %}
+
+
+    {% if documentation_resources %}
+    <br>
+      <h2>{{ _('Documentation  ') }}</h2>
+      {% block documentation_resource_list %}
+        {% if documentation_resources %}
+          {% set can_edit = can_edit or h.check_access('package_update', {'id':pkg.id }) %}
+          <ul class="{% block documentation_resource_list_class %}resource-list{% endblock %}">
+            {% block documentation_resource_list_inners %}
+              {% for resource in documentation_resources %}
+                {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, can_edit=can_edit %}
+              {% endfor %}
+            {% endblock %}
+          </ul>
+        {% endif %}
+      {% endblock %}
+    {% endif %}
+
+
+    {% if historic_resources %}
+    <br>
+      <h2>{{ _('Historic  Data') }}</h2>
+      {% block historic_resources_list %}
+        {% if historic_resources %}
+          {% set can_edit = can_edit or h.check_access('package_update', {'id':pkg.id }) %}
+          <ul class="{% block historic_resources_list_class %}resource-list{% endblock %}">
+            {% block historic_resources_list_inners %}
+              {% for resource in historic_resources %}
+                {% snippet 'package/snippets/resource_item.html', pkg=pkg, res=resource, can_edit=can_edit %}
+              {% endfor %}
+            {% endblock %}
+          </ul>
+        {% endif %}
+      {% endblock %}
+    {% endif %}
+
+  </section>
+
+
+
+  
+
+
+  

--- a/ckanext/sse/validators.py
+++ b/ckanext/sse/validators.py
@@ -116,8 +116,10 @@ def schema_output_string_json(value, context):
 
 
 def resource_type_validator(value, context):
-    if value not in ["regular", "documentation"]:
-        raise Invalid(_(' Resource type must be either "regular" or "documentation"'))
+    if value not in ["regular", "documentation", "historic"]:
+        raise Invalid(
+            _('Resource type must be either "regular", "documentation" or , "historic"')
+        )
     return value
 
 


### PR DESCRIPTION
Fix For : https://github.com/datopian/client-sse-networks-shared/issues/101
Resource type can be selected as regular, documentation and historic.

The publisher can also view resources in different sections based on selected types.

<img width="1506" alt="Screenshot 2024-01-23 at 2 23 35 PM" src="https://github.com/datopian/ckanext-sse/assets/87696933/4d5d7511-9bef-436a-b0ce-4ef4561f31dd">
