### PR TITLE
Mint frontend_token with explicit expiry

### DIFF
--- a/ckanext/sse/action.py
+++ b/ckanext/sse/action.py
@@ -518,8 +518,27 @@ def _generate_token(context, user):
             if token["name"] == "frontend_token":
                 tk.get_action("api_token_revoke")(context, {"jti": token["id"]})
 
+        # Mint the frontend_token with an explicit lifetime so it expires even
+        # when the expire_api_token plugin is enabled. The plugin computes the
+        # token TTL as expires_in * unit (seconds); if we do not pass these it
+        # falls back to expire_api_token.default_lifetime. We keep it explicit
+        # and env-overridable so the lifetime is a deliberate policy value.
+        # The frontend (ssen-portal) re-mints this token on expiry, so a short
+        # lifetime here does not break the long-lived NextAuth session.
+        frontend_token_expires_in = int(
+            os.environ.get("CKANEXT__SSE__FRONTEND_TOKEN_EXPIRES_IN", 1)
+        )
+        frontend_token_unit = int(
+            os.environ.get("CKANEXT__SSE__FRONTEND_TOKEN_UNIT", 3600)
+        )
         frontend_token = tk.get_action("api_token_create")(
-            context, {"user": user["name"], "name": "frontend_token"}
+            context,
+            {
+                "user": user["name"],
+                "name": "frontend_token",
+                "expires_in": frontend_token_expires_in,
+                "unit": frontend_token_unit,
+            },
         )
 
         user["frontend_token"] = frontend_token.get("token")


### PR DESCRIPTION
## What
Mint the CKAN `frontend_token` in `_generate_token` with an explicit `expires_in`/`unit` (default 1h, env-overridable via `CKANEXT__SSE__FRONTEND_TOKEN_EXPIRES_IN` / `_UNIT`) instead of relying on the plugin default.

## Why
Threat Model Remediation issue #324, Row 8 — "Enable CKAN token expiry". The `expire_api_token` plugin exists but was disabled. Enabling it makes `expires_in`/`unit` required at mint time; this sets them explicitly so the lifetime is a deliberate policy value rather than the implicit 3600s default.

## Coordinated changes
- Frontend re-mints this token before expiry (ssen-portal PR).
- Plugin enabled + datapusher token given a long lifetime (dx-helm-sse-prod / dx-helm-sse-dev PRs).

Merge order: this + helm PRs together, frontend before/with rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Frontend API tokens now use a configurable expiration duration.
  * Added default token lifetime settings to ensure predictable expiration behavior.
  * Existing frontend tokens continue to be revoked before a new token is issued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->