### PR TITLE
fix(audit): recover the real client IP from behind Cloudflare

### DIFF
--- a/ckanext/sse/audit.py
+++ b/ckanext/sse/audit.py
@@ -20,6 +20,20 @@ anonymous user. Successful logins are captured through flask-login's
 ``user_logged_in`` signal, which ``login_user()`` sends once the user object
 has been established. Failures come from CKAN's own ``failed_login`` signal
 (``ckan/lib/authenticator.py``).
+
+Recovering the client address takes two different routes depending on the
+environment, both measured rather than assumed:
+
+* Without a CDN (ckan-dev.sse.datopian.com) ingress-nginx replaces
+  ``X-Forwarded-For`` with the address it observed, so the chain arrives with a
+  single trustworthy entry and that entry is the client.
+* Behind Cloudflare (ckan-prod.sse.datopian.com) the address nginx observes is
+  a Cloudflare edge, and because nginx discards the incoming header,
+  Cloudflare's own ``X-Forwarded-For`` -- the one carrying the real client -- is
+  thrown away before CKAN sees it. Hop counting cannot recover it; there is
+  nothing left in the chain to count to. ``CF-Connecting-IP`` survives, and is
+  honoured only when the address nginx observed is itself inside Cloudflare's
+  published ranges, so a request reaching the origin directly cannot forge it.
 """
 
 import datetime
@@ -53,7 +67,28 @@ EVENT_TYPE = "security_audit"
 # (a CDN, for instance); each one shifts the real client one place further
 # left. Measured against ckan-dev.sse.datopian.com: the chain arrives with a
 # single entry, so 0 is correct there.
+#
+# Note this cannot recover the client from behind a CDN that nginx does not
+# trust -- see CF-Connecting-IP handling below.
 DEFAULT_TRUSTED_PROXIES = 0
+
+# Header a trusted CDN uses to carry the original client address. Set to an
+# empty value to disable the lookup entirely.
+DEFAULT_CLIENT_IP_HEADER = "CF-Connecting-IP"
+
+# Cloudflare's published edge ranges, from https://www.cloudflare.com/ips-v4
+# and ips-v6 (retrieved 2026-07-29). CF-Connecting-IP is honoured only when the
+# address nginx observed falls inside one of these, so an attacker reaching the
+# origin directly cannot dictate the client address by setting the header.
+# Override with ``ckanext.sse.audit.cdn_cidrs`` when these change.
+DEFAULT_CDN_CIDRS = """
+173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22
+141.101.64.0/18 108.162.192.0/18 190.93.240.0/20 188.114.96.0/20
+197.234.240.0/22 198.41.128.0/17 162.158.0.0/15 104.16.0.0/13
+104.24.0.0/14 172.64.0.0/13 131.0.72.0/22
+2400:cb00::/32 2606:4700::/32 2803:f800::/32 2405:b500::/32
+2405:8100::/32 2a06:98c0::/29 2c0f:f248::/32
+"""
 
 
 def get_subscriptions():
@@ -95,14 +130,73 @@ def _request_context():
     environ = toolkit.request.environ
     forwarded_for = environ.get("HTTP_X_FORWARDED_FOR")
     remote_addr = environ.get("REMOTE_ADDR")
+    cdn_client_ip = environ.get(_client_ip_header_key())
 
     return {
-        "source_ip": _client_ip(forwarded_for, remote_addr),
+        "source_ip": _client_ip(forwarded_for, remote_addr, cdn_client_ip),
         "forwarded_for": forwarded_for,
         "remote_addr": remote_addr,
+        # What the trusted proxy says it saw connect, and the CDN's claim about
+        # the original client. Both kept so a wrong trust decision stays
+        # auditable after the fact.
+        "observed_peer": _observed_peer(forwarded_for, remote_addr),
+        "cdn_client_ip": cdn_client_ip,
         "user_agent": environ.get("HTTP_USER_AGENT"),
         "request_path": toolkit.request.path,
     }
+
+
+def _client_ip_header_key():
+    """WSGI environ key for the configured CDN client-address header."""
+    name = toolkit.config.get(
+        "ckanext.sse.audit.client_ip_header", DEFAULT_CLIENT_IP_HEADER
+    )
+    if not name:
+        return ""
+    return "HTTP_" + name.strip().upper().replace("-", "_")
+
+
+def _observed_peer(forwarded_for, remote_addr):
+    """The address our trusted proxy reports as having connected to it.
+
+    ingress-nginx writes this as the rightmost X-Forwarded-For entry, so it is
+    an attestation rather than a client claim. Outside a trusted peer there is
+    nothing to attest and the connecting address is all we have.
+    """
+    if not _peer_is_trusted(remote_addr):
+        return remote_addr
+    chain = _forwarded_chain(forwarded_for)
+    return chain[-1] if chain else remote_addr
+
+
+def _forwarded_chain(forwarded_for):
+    if not forwarded_for:
+        return []
+    return [part.strip() for part in forwarded_for.split(",") if part.strip()]
+
+
+def _in_cdn_range(address):
+    """Whether ``address`` is a published CDN edge, i.e. may set the header."""
+    if not address:
+        return False
+    try:
+        addr = ipaddress.ip_address(address)
+    except ValueError:
+        return False
+    addr = getattr(addr, "ipv4_mapped", None) or addr
+
+    configured = toolkit.config.get("ckanext.sse.audit.cdn_cidrs", DEFAULT_CDN_CIDRS)
+    for entry in re.split(r"[,\s]+", (configured or "").strip()):
+        if not entry:
+            continue
+        try:
+            if addr in ipaddress.ip_network(entry, strict=False):
+                return True
+        except ValueError:
+            log.warning(
+                "Ignoring invalid ckanext.sse.audit.cdn_cidrs entry %r", entry
+            )
+    return False
 
 
 def _trusted_proxy_count():
@@ -162,23 +256,35 @@ def _peer_is_trusted(remote_addr):
     return False
 
 
-def _client_ip(forwarded_for, remote_addr):
-    """Pick the client address out of the X-Forwarded-For chain.
+def _client_ip(forwarded_for, remote_addr, cdn_client_ip=None):
+    """Resolve the client address.
 
-    Falls back to the connecting peer whenever the chain cannot be trusted. The
-    raw chain is logged alongside the result, so a wrong
-    ``ckanext.sse.audit.trusted_proxies`` setting loses no information.
+    Falls back to the connecting peer whenever nothing more trustworthy is
+    available. Every input is logged alongside the result, so a wrong trust
+    decision loses no information and can be recomputed later.
     """
     if not forwarded_for or not _peer_is_trusted(remote_addr):
         return remote_addr
 
-    chain = [part.strip() for part in forwarded_for.split(",") if part.strip()]
+    chain = _forwarded_chain(forwarded_for)
     if not chain:
         return remote_addr
 
-    # Count in from the right: the rightmost entry is the one our trusted proxy
-    # wrote. Clamps to the leftmost entry if the chain is shorter than the
-    # configured hop count.
+    # The rightmost entry is the one our trusted proxy wrote, so it says who
+    # actually connected to it. If that was a CDN edge, the CDN's header is the
+    # only remaining record of the original client -- nginx discarded the
+    # forwarded chain the CDN sent.
+    if cdn_client_ip and _in_cdn_range(chain[-1]):
+        candidate = cdn_client_ip.split(",")[0].strip()
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            log.warning("Ignoring malformed CDN client address %r", cdn_client_ip)
+        else:
+            return candidate
+
+    # Count in from the right. Clamps to the leftmost entry if the chain is
+    # shorter than the configured hop count.
     index = max(0, len(chain) - 1 - _trusted_proxy_count())
     return chain[index]
 


### PR DESCRIPTION
## The problem

`source_ip` on prod records a **Cloudflare edge address, not the user**. Measured on `ckan-prod.sse.datopian.com` from a real failed login:

```json
{"user_name": "demenech", "source_ip": "172.71.235.22",
 "forwarded_for": "172.71.235.22", "remote_addr": "::ffff:10.60.14.12"}
```

`172.71.235.22` is Cloudflare — `172.64.0.0/13`, ASN 13335. So every prod audit entry currently says "which Cloudflare datacenter relayed this", which is useless for attribution and actively misleading in a security log.

## Why hop counting can't fix it

ingress-nginx has `use-forwarded-headers` unset. The key exists only in `ingress-controller-leader-nginx-production` — the leader-election ConfigMap — where it has no effect; the real controller ConfigMap (`nginx-ingress-production-ingress-nginx-controller`) doesn't contain it. So nginx **discards** the `X-Forwarded-For` Cloudflare sends and replaces it with the address it observed, which is the edge.

The real client is gone from the chain entirely. `trusted_proxies` counts positions within the chain, and there is no longer a position holding the client, so no value of it recovers anything. Confirmed by the single-entry `forwarded_for` above.

## The fix

`CF-Connecting-IP` survives nginx's rewrite. It's now used — but only when the **rightmost `X-Forwarded-For` entry** falls inside Cloudflare's published ranges.

That entry is the one nginx wrote, so it's an attestation of who actually connected, not a client claim. This matters because the prod ingress has no `whitelist-source-range` annotation: without the check, anyone reaching the origin directly could set `CF-Connecting-IP` and choose what the audit log records.

Ranges ship in code from [cloudflare.com/ips-v4](https://www.cloudflare.com/ips-v4) / [ips-v6](https://www.cloudflare.com/ips-v6) (retrieved 2026-07-29), overridable via `ckanext.sse.audit.cdn_cidrs`. Header name is `ckanext.sse.audit.client_ip_header` (default `CF-Connecting-IP`); an empty value disables the lookup.

**Dev is unaffected** — not Cloudflare-proxied, so the observed peer isn't in a CDN range and resolution falls through to the existing chain logic.

The payload gains `observed_peer` and `cdn_client_ip`, so a wrong trust decision stays auditable and can be recomputed from history rather than lost.

## Verification

Exercised the real module with CKAN's imports stubbed (18 cases, all passing). The ones that matter here:

| case | result |
|---|---|
| CF edge peer + `CF-Connecting-IP` | returns the real client ✅ |
| non-CDN peer claiming a CF header | header ignored, chain logic used ✅ |
| untrusted peer forging chain **and** header | falls back to the connecting address ✅ |
| malformed `CF-Connecting-IP` | ignored, no crash ✅ |
| lookup disabled by config | falls through ✅ |

Regression cases from #22 still pass: spoofed chain rejected, negative/non-integer `trusted_proxies` no longer raise, `_request_context()` failures stay contained.

One gotcha found while writing those tests, worth knowing for future ones: Python's `ipaddress.is_private` treats the RFC 5737 documentation ranges (`198.51.100.0/24`, `203.0.113.0/24`, `192.0.2.0/24`) as private, so they count as *trusted* peers. Harmless in production — those never appear as real peers — but it silently invalidates any test that uses them as a stand-in for a public attacker.

## Still no automated tests in-repo

`test.ini` points at `config:../ckan/test-core.ini`, which doesn't resolve under the dev container layout. The stub harness above is throwaway. Happy to land these as real pytest cases once that path is fixed — worth doing, since the trust logic now has enough branches that a regression would be silent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication audit events now capture more accurate source IP information when requests pass through trusted proxies or CDN services.
  * Recorded network attribution includes forwarded address details and the resolved client IP.

* **Documentation**
  * Updated guidance explains how client addresses are recovered with and without CDN configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->