### PR TITLE
feat(audit): log API token issuance, use and revocation

### DIFF
--- a/audit-smoke.sh
+++ b/audit-smoke.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Drives every API audit event against the local dev CKAN and prints what the
+# plugin emitted. Creates a throwaway token, uses it, revokes it, reuses it.
+set -uo pipefail
+
+CKAN_URL=${CKAN_URL:-http://localhost:5000}
+CONTAINER=${CONTAINER:-ssen-ckan-dev}
+INI=${INI:-/srv/app/ckan.ini}
+ADMIN=${ADMIN:-ckan_admin}
+NAME="audit-smoke-$$"
+
+api() { # api <action> [json-body] [token]
+  local action=$1 body=${2:-} token=${3:-}
+  local args=(-s -o /dev/null -w '%{http_code}')
+  [ -n "$token" ] && args+=(-H "Authorization: $token")
+  if [ -n "$body" ]; then
+    args+=(-X POST -H 'Content-Type: application/json' -d "$body")
+  fi
+  curl "${args[@]}" "$CKAN_URL/api/3/action/$action"
+}
+
+START=$(date -u +%s)
+
+echo "==> minting a bootstrap token for $ADMIN"
+BOOT=$(docker exec "$CONTAINER" ckan -c "$INI" user token add "$ADMIN" "$NAME-boot" \
+        2>/dev/null | tail -1 | tr -d ' \t\r\n')
+[ -n "$BOOT" ] || { echo "could not mint token"; exit 1; }
+
+echo -n "  anonymous read            -> "; api status_show
+echo -n "  token issue (API)         -> "
+TOK=$(curl -s -X POST -H "Authorization: $BOOT" -H 'Content-Type: application/json' \
+      -d "{\"user\":\"$ADMIN\",\"name\":\"$NAME\"}" \
+      "$CKAN_URL/api/3/action/api_token_create" \
+      | python3 -c 'import sys,json; print(json.load(sys.stdin)["result"]["token"])' 2>/dev/null)
+[ -n "$TOK" ] && echo "ok" || { echo "FAILED"; exit 1; }
+
+echo -n "  token read                -> "; api package_list '' "$TOK"
+echo -n "  forged token              -> "; api package_list '' "eyJhbGciOiJIUzI1NiJ9.FORGED.x"
+echo -n "  basic auth (not a token)  -> "; \
+  curl -s -o /dev/null -w '%{http_code}\n' -H 'Authorization: Basic ZGV2OnB3' "$CKAN_URL/api/3/action/status_show"
+# Deliberately omits the required `email`, so this 409s and changes nothing --
+# the audit line is still emitted, with the password redacted. Sending a valid
+# user_update here would really reset the admin password on every run.
+echo -n "  secret in params (409)    -> "; api user_update "{\"id\":\"$ADMIN\",\"password\":\"REDACT_ME_PLEASE\"}" "$BOOT"
+echo -n "  denied (anonymous write)  -> "; api package_create '{"name":"nope"}'
+echo -n "  revoke                    -> "; api api_token_revoke "{\"token\":\"$TOK\"}" "$BOOT"
+echo -n "  reuse after revoke        -> "; api package_list '' "$TOK"
+
+# Out of scope: only /api/*/action/* is audited. These must produce no events,
+# including the one carrying a token -- scope is the action API, not "/api".
+echo -n "  [noise] UI page           -> "; curl -s -o /dev/null -w '%{http_code}\n' "$CKAN_URL/dataset"
+echo -n "  [noise] i18n bundle       -> "; curl -s -o /dev/null -w '%{http_code}\n' "$CKAN_URL/api/i18n/en"
+echo -n "  [noise] autocomplete      -> "; curl -s -o /dev/null -w '%{http_code}\n' "$CKAN_URL/api/util/dataset/autocomplete?incomplete=a"
+echo -n "  [noise] i18n with token   -> "; curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: $BOOT" "$CKAN_URL/api/i18n/en"
+
+echo "==> cleanup"
+BOOT_JTI=$(docker exec "$CONTAINER" ckan -c "$INI" user token list "$ADMIN" 2>/dev/null \
+           | grep -F "$NAME-boot" | grep -oE '\[[^]]+\]' | tr -d '[]')
+[ -n "$BOOT_JTI" ] && docker exec "$CONTAINER" ckan -c "$INI" user token revoke "$BOOT_JTI" >/dev/null 2>&1
+echo "  revoked $NAME-boot"
+
+echo
+echo "==> events emitted"
+docker logs --since "$((  $(date -u +%s) - START + 5 ))s" "$CONTAINER" 2>&1 \
+  | grep '"event_type": "security_audit"' \
+  | jq -r '[.timestamp[11:19], .action, .status, (.token_auth // "-"),
+            (.api_action // "-"), ((.token_id // "-")[0:10]), .user_name,
+            (.params // {} | tostring)[0:38]] | @tsv' \
+  | column -t -s$'\t'
+
+echo
+echo "==> assertions"
+LOG=$(docker logs --since "$((  $(date -u +%s) - START + 5 ))s" "$CONTAINER" 2>&1 | grep '"event_type": "security_audit"')
+fail=0
+want() { # want <description> <jq-filter>
+  if echo "$LOG" | jq -s -e "any(.[]; $2)" >/dev/null 2>&1; then echo "  PASS  $1"; else echo "  FAIL  $1"; fail=1; fi
+}
+want "issuance logged with jti"       '.action=="api_token_issued" and .token_id!=null'
+want "revocation logged"              '.action=="api_token_revoked"'
+want "live token -> token"            '.token_auth=="token" and .status=="success"'
+want "forged token -> token_invalid"  '.token_auth=="token_invalid" and .status=="failure"'
+want "revoked reuse -> token_revoked" '.token_auth=="token_revoked" and .status=="failure"'
+want "403 -> failure"                 '.api_action=="package_create" and .status=="failure"'
+want "password redacted"              '.params.password=="<redacted>"'
+want "raw token never logged"         '.params.token=="<redacted>"'
+want "validation error logged, not 500" '.api_action=="user_update" and .http_status==409'
+echo "$LOG" | grep -q 'REDACT_ME_PLEASE' && { echo "  FAIL  secret leaked into log"; fail=1; } \
+                                          || echo "  PASS  secret absent from log"
+echo "$LOG" | jq -s -e 'any(.[]; .token_auth=="token_invalid" and .request_path=="/api/3/action/status_show")' >/dev/null 2>&1 \
+  && { echo "  FAIL  basic auth mistaken for token"; fail=1; } || echo "  PASS  basic auth not a token"
+echo "$LOG" | jq -s -e 'any(.[]; .request_path | test("/action/") | not)' >/dev/null 2>&1 \
+  && { echo "  FAIL  non-action request logged"; fail=1; } || echo "  PASS  only action API logged"
+
+exit $fail

--- a/ckanext/sse/audit.py
+++ b/ckanext/sse/audit.py
@@ -1,4 +1,4 @@
-"""Structured security audit logging for authentication events.
+"""Structured security audit logging for authentication and API events.
 
 Emits one JSON object per event, one line each, straight to stdout for the
 centralised log collector to pick up.
@@ -20,6 +20,28 @@ anonymous user. Successful logins are captured through flask-login's
 ``user_logged_in`` signal, which ``login_user()`` sends once the user object
 has been established. Failures come from CKAN's own ``failed_login`` signal
 (``ckan/lib/authenticator.py``).
+
+API activity is covered by three further events, none of which CKAN exposes as
+a single signal:
+
+* ``api_token_issued`` -- ``IApiToken.postprocess_api_token()`` is the only
+  hook handed the token id, and it runs solely inside ``api_token_create``.
+  The ``action_succeeded`` signal is no use here: its ``result`` is
+  ``{"token": <the raw secret>}`` and carries no id.
+* ``api_token_revoked`` -- ``action_succeeded`` filtered to the
+  ``api_token_revoke`` sender.
+* ``api_request`` -- one event per call to the action API
+  (``/api/3/action/<name>``), and nothing else: the rest of the ``/api``
+  blueprint is browser plumbing. Emitted from ``request_finished`` rather
+  than ``action_succeeded`` because the latter only fires on success, and a
+  ``NotAuthorized`` or a token that fails to decode is exactly what an audit
+  trail exists to record. The token id comes from
+  ``IApiToken.preprocess_api_token()``, which runs once per token-authenticated
+  request on the way to the database lookup.
+
+Nothing derived from a request body is logged verbatim. Parameters are
+redacted by key name and size-capped before they are serialised -- see
+``_audit_params()`` for why both are load-bearing.
 
 Recovering the client address takes two different routes depending on the
 environment, both measured rather than assumed:
@@ -43,7 +65,7 @@ import logging
 import re
 import sys
 
-from flask import has_request_context
+from flask import g, has_request_context
 from flask_login import user_logged_in
 
 import ckan.plugins as plugins
@@ -90,11 +112,41 @@ DEFAULT_CDN_CIDRS = """
 2405:8100::/32 2a06:98c0::/29 2c0f:f248::/32
 """
 
+# Request attribute carrying the id of the token this request authenticated
+# with. Set by ``preprocess_api_token``, read once the response is ready.
+TOKEN_ID_ATTR = "sse_audit_token_id"
+
+# Parameter names whose values must never reach the log, matched
+# case-insensitively against the whole key. ``api_token_revoke`` takes the raw
+# token as ``token``; the user actions take passwords in several spellings.
+# Audit output goes to stdout and from there to a log store with a much wider
+# reader set than the database, so a leak here is a real credential
+# disclosure. Override with ``ckanext.sse.audit.redacted_params``.
+DEFAULT_REDACTED_PARAMS = """
+password password1 password2 old_password new_password pass
+token api_token apikey api_key key secret client_secret
+"""
+
+# Caps on the serialised parameter dict.
+#
+# These are not tidiness. A log line long enough to be chopped by the
+# collector arrives as invalid JSON and takes the whole event with it, so a
+# single ``datastore_upsert`` with a large ``records`` list would silently
+# destroy its own audit record. Individual values are trimmed first; if the
+# dict is still over budget the values are dropped and only the key names
+# survive, which is the part that matters for an audit trail anyway.
+DEFAULT_MAX_PARAM_VALUE = 512
+DEFAULT_MAX_PARAMS = 4096
+
 
 def get_subscriptions():
     return {
         user_logged_in: [on_user_logged_in],
         toolkit.signals.failed_login: [on_failed_login],
+        toolkit.signals.request_finished: [on_request_finished],
+        toolkit.signals.action_succeeded: [
+            {"sender": "api_token_revoke", "receiver": on_api_token_revoked},
+        ],
     }
 
 
@@ -103,10 +155,10 @@ def on_user_logged_in(sender, user=None, **kwargs):
     emit_audit_log(
         action="user_login",
         status="success",
-        user_name=getattr(user, "name", None),
-        user_id=getattr(user, "id", None),
+        user_name=_safe_attr(user, "name"),
+        user_id=_safe_attr(user, "id"),
         message="Successful login for user {}".format(
-            getattr(user, "name", "unknown")
+            _safe_attr(user, "name") or "unknown"
         ),
     )
 
@@ -120,6 +172,258 @@ def on_failed_login(sender, **kwargs):
         user_name=attempted,
         message="Failed login attempt for {}".format(attempted or "unknown"),
     )
+
+
+def on_api_token_revoked(sender, **kwargs):
+    """CKAN ``action_succeeded`` for ``api_token_revoke``.
+
+    ``api_token_revoke`` accepts either a ``jti`` or the raw token, and when
+    given the latter it decodes it locally without telling anyone the id it
+    arrived at. Decoding it again here would mean handling the secret a second
+    time for a field that is nearly always present anyway, so a revocation by
+    token value is recorded as such and left without an id.
+    """
+    data_dict = kwargs.get("data_dict") or {}
+    context = kwargs.get("context") or {}
+    jti = data_dict.get("jti")
+    emit_audit_log(
+        action="api_token_revoked",
+        status="success",
+        user_name=context.get("user"),
+        user_id=_safe_attr(context.get("auth_user_obj"), "id"),
+        message="API token {} revoked".format(jti or "(identified by value)"),
+        token_id=jti,
+        revoked_by="jti" if jti else "token_value",
+    )
+
+
+def on_request_finished(sender, response=None, **kwargs):
+    """Flask ``request_finished``, re-sent by CKAN, once the response exists.
+
+    Fires for 4xx as well as 2xx, which is the reason for using it in
+    preference to ``action_succeeded``: a denied or malformed API call is the
+    event most worth having. It does not fire when an exception escapes
+    unhandled, so a hard 500 leaves no line -- CKAN's error handlers catch
+    almost everything, but not quite everything.
+
+    The whole body is inside the failure boundary, not just the write.
+    ``finalize_request`` does not guard its own signal, so anything raised
+    here replaces the response CKAN had already built: a 409 validation error
+    came back as a 500 until this was in place.
+    """
+    try:
+        _log_api_request(response)
+    except Exception:
+        log.exception("Failed to emit API request audit log")
+
+
+def _safe_attr(obj, attr):
+    """Read an attribute off a possibly-detached SQLAlchemy instance.
+
+    ``current_user`` is a ``User`` row, and when an action fails CKAN rolls
+    the session back before the response is finalised. The instance is then
+    detached with its attributes expired, so reading one attempts a refresh
+    and raises ``DetachedInstanceError``. Observed on a ``user_update`` that
+    failed validation, not a theoretical concern.
+    """
+    if obj is None:
+        return None
+    try:
+        return getattr(obj, attr, None)
+    except Exception:
+        return None
+
+
+def _log_api_request(response):
+    if not has_request_context() or not _is_audited_request():
+        return
+
+    status_code = getattr(response, "status_code", None)
+    token_id = getattr(g, TOKEN_ID_ATTR, None)
+    user = toolkit.current_user
+    authenticated = not _safe_attr(user, "is_anonymous") if user else False
+
+    if token_id and authenticated:
+        token_auth = "token"
+    elif token_id:
+        # The JWT decoded -- so it was validly signed and unexpired, and
+        # ``preprocess_api_token`` saw its id -- but no user came back, which
+        # means ``ApiToken.get(jti)`` found no row. The token was revoked or
+        # its owner was deleted. Distinguishing this from a live token matters
+        # more than any other case here: use of a withdrawn credential is the
+        # signal, and it is invisible in the response, which is a perfectly
+        # ordinary anonymous 200 on any endpoint that permits anonymous reads.
+        token_auth = "token_revoked"
+    elif _token_presented():
+        # A token arrived but never reached the database lookup, so it failed
+        # to decode: expired, signed with another key, or forged.
+        token_auth = "token_invalid"
+    elif authenticated:
+        token_auth = "session"
+    else:
+        token_auth = "anonymous"
+
+    failed = token_auth in ("token_invalid", "token_revoked") or (
+        status_code is not None and status_code >= 400
+    )
+
+    api_action = _api_action()
+    emit_audit_log(
+        action="api_request",
+        # An unusable token is an authentication failure even when the
+        # endpoint went on to serve the request anonymously with a 200.
+        status="failure" if failed else "success",
+        user_name=_safe_attr(user, "name") if authenticated else None,
+        user_id=_safe_attr(user, "id") if authenticated else None,
+        message="API request {} {}".format(
+            toolkit.request.method, api_action or toolkit.request.path
+        ),
+        api_action=api_action,
+        http_status=status_code,
+        token_id=token_id,
+        token_auth=token_auth,
+        params=_audit_params(),
+    )
+
+
+def _is_audited_request():
+    """Whether this request is a call to the action API.
+
+    Scoped to the action API alone -- ``/api/3/action/<name>`` and the
+    unversioned ``/api/action/<name>``. Everything else is out, including the
+    rest of the ``/api`` blueprint: the root version document, the autocomplete
+    helpers, the template snippet fetcher and the JavaScript translation bundle
+    are browser plumbing pulled by every page load, and logging them buries the
+    events that matter.
+
+    Detected by the presence of the ``logic_function`` view argument, which is
+    what defines an action route, rather than by endpoint or blueprint name.
+    Those are not stable: ckanext-googleanalytics re-registers the same two
+    URL rules under its own blueprint to count API calls, so on this
+    deployment the endpoint is ``google_analytics.action`` and the blueprint is
+    ``google_analytics``. Any extension wrapping the action API would shadow
+    the name the same way; none of them can drop the view argument without
+    breaking the route itself.
+
+    The path check keeps an extension that borrows the same argument name for
+    a non-API route from being pulled in.
+    """
+    if "logic_function" not in (toolkit.request.view_args or {}):
+        return False
+    return toolkit.request.path.startswith("/api/")
+
+
+def _api_action():
+    """The CKAN action name, taken from the route rather than the body.
+
+    ``/api/3/action/<logic_function>`` binds the name as a view arg, so it is
+    already parsed and correct even for requests that failed before the body
+    was read.
+    """
+    view_args = toolkit.request.view_args or {}
+    return view_args.get("logic_function") or toolkit.request.endpoint
+
+
+def _token_presented():
+    """Whether the request carried something CKAN would try to read as a token.
+
+    Mirrors ``ckan.views._get_user_for_apitoken`` (2.10): the configured header
+    first, then a bare ``Authorization``. A value containing a space is an HTTP
+    auth scheme (``Basic``, ``Bearer``, ``Digest``) rather than a token -- CKAN
+    applies that rule to only one of its lookups, but the dev portal sits
+    behind basic auth, so without applying it here every request there would be
+    filed as a failed token attempt.
+    """
+    header = toolkit.config.get("apikey_header_name", "X-CKAN-API-Key")
+    environ = toolkit.request.environ
+    candidates = [
+        toolkit.request.headers.get(header, ""),
+        environ.get(header, ""),
+        environ.get("HTTP_AUTHORIZATION", ""),
+        environ.get("Authorization", ""),
+    ]
+    return any(value and " " not in value for value in candidates)
+
+
+def _audit_params():
+    """Everything the caller supplied, redacted and size-capped.
+
+    The union of query string, form and JSON body rather than CKAN's own
+    precedence rules: for an audit trail what was *presented* matters, not
+    which copy the action happened to read. All three are already parsed and
+    cached on the request by the view, so this costs nothing to re-read.
+    """
+    request = toolkit.request
+    raw = {}
+    raw.update(request.args.to_dict(flat=True))
+    raw.update(request.form.to_dict(flat=True))
+
+    body = request.get_json(silent=True)
+    if isinstance(body, dict):
+        raw.update(body)
+
+    # File contents are never logged; the field and filename are the audit
+    # trail, and the bytes are the resource itself.
+    for field, storage in request.files.items():
+        raw[field] = "<file:{}>".format(
+            getattr(storage, "filename", None) or "unnamed"
+        )
+
+    redacted = {
+        key: (
+            "<redacted>"
+            if key.lower() in _redacted_param_names()
+            else _trim_value(value)
+        )
+        for key, value in raw.items()
+    }
+
+    max_total = _int_config(
+        "ckanext.sse.audit.max_params_bytes", DEFAULT_MAX_PARAMS
+    )
+    if len(json.dumps(redacted, default=str)) <= max_total:
+        return redacted
+
+    # Still over budget after per-value trimming, so keep the shape and lose
+    # the content. Which parameters were sent is the part an investigation
+    # needs; the values of a bulk upsert are not.
+    return {"__truncated__": True, "__keys__": sorted(raw)}
+
+
+def _trim_value(value):
+    """Serialise one parameter value, bounded."""
+    if not isinstance(value, (str, int, float, bool, type(None))):
+        value = json.dumps(value, default=str)
+    if not isinstance(value, str):
+        return value
+
+    limit = _int_config(
+        "ckanext.sse.audit.max_param_value", DEFAULT_MAX_PARAM_VALUE
+    )
+    if len(value) <= limit:
+        return value
+    return value[:limit] + "...<truncated {} chars>".format(len(value) - limit)
+
+
+def _redacted_param_names():
+    configured = toolkit.config.get(
+        "ckanext.sse.audit.redacted_params", DEFAULT_REDACTED_PARAMS
+    )
+    return {
+        name.lower()
+        for name in re.split(r"[,\s]+", (configured or "").strip())
+        if name
+    }
+
+
+def _int_config(key, default):
+    """An int setting, normalised so a bad value cannot break a request."""
+    try:
+        value = toolkit.asint(toolkit.config.get(key, default))
+    except (ValueError, TypeError):
+        log.warning("Ignoring invalid %s, using %s", key, default)
+        return default
+    return value if value > 0 else default
 
 
 def _request_context():
@@ -143,6 +447,7 @@ def _request_context():
         "cdn_client_ip": cdn_client_ip,
         "user_agent": environ.get("HTTP_USER_AGENT"),
         "request_path": toolkit.request.path,
+        "http_method": toolkit.request.method,
     }
 
 
@@ -289,12 +594,13 @@ def _client_ip(forwarded_for, remote_addr, cdn_client_ip=None):
     return chain[index]
 
 
-def emit_audit_log(action, status, message, user_name=None, user_id=None):
+def emit_audit_log(action, status, message, user_name=None, user_id=None,
+                   **extra):
     # A broken audit line must never break the request it describes. These
-    # functions run inside signal receivers on the login and logout paths, so
-    # gathering the context has to be inside the boundary too, not just the
-    # write. Failures go to the logger (stderr), where an ERROR severity is
-    # accurate.
+    # functions run inside signal receivers on the login, logout and request
+    # paths, so gathering the context has to be inside the boundary too, not
+    # just the write. Failures go to the logger (stderr), where an ERROR
+    # severity is accurate.
     try:
         payload = {
             "event_type": EVENT_TYPE,
@@ -310,17 +616,21 @@ def emit_audit_log(action, status, message, user_name=None, user_id=None):
             "user_id": user_id,
             "message": message,
         }
+        payload.update(extra)
         payload.update(_request_context())
-        print(json.dumps(payload), file=sys.stdout, flush=True)
+        # ``default=str`` so an unserialisable parameter value degrades to its
+        # repr rather than losing the whole event.
+        print(json.dumps(payload, default=str), file=sys.stdout, flush=True)
     except Exception:
         log.exception("Failed to emit security audit log for %s", action)
 
 
 class SecurityAuditPlugin(plugins.SingletonPlugin):
-    """Logs authentication events as structured JSON."""
+    """Logs authentication and API events as structured JSON."""
 
     plugins.implements(plugins.IAuthenticator, inherit=True)
     plugins.implements(plugins.ISignal)
+    plugins.implements(plugins.IApiToken, inherit=True)
 
     # ISignal
     def get_signal_subscriptions(self):
@@ -333,11 +643,60 @@ class SecurityAuditPlugin(plugins.SingletonPlugin):
         Returns None to leave CKAN's logout flow untouched.
         """
         user = toolkit.current_user
-        name = getattr(user, "name", None) if user else None
+        name = _safe_attr(user, "name")
         emit_audit_log(
             action="user_logout",
             status="success",
             user_name=name,
-            user_id=getattr(user, "id", None) if user else None,
+            user_id=_safe_attr(user, "id"),
             message="User {} logged out".format(name or "unknown"),
         )
+
+    # IApiToken
+    def preprocess_api_token(self, data):
+        """Runs once per token-authenticated request, before the DB lookup.
+
+        The only point on the authentication path where the token id is
+        available. Stashed rather than emitted here because the outcome of the
+        request is not known yet, and because the same id has to appear on the
+        ``api_request`` event for the two to be correlated.
+
+        ``get_user_from_token()`` is also reachable from the CLI, where there
+        is no request to attach anything to.
+        """
+        try:
+            if has_request_context() and isinstance(data, dict):
+                setattr(g, TOKEN_ID_ATTR, data.get("jti"))
+        except Exception:
+            log.exception("Failed to record API token id for audit")
+        return data
+
+    # IApiToken
+    def postprocess_api_token(self, data, jti, data_dict):
+        """Runs inside ``api_token_create`` once the token row is committed.
+
+        ``data_dict`` is the validated create payload, so ``user`` is the
+        owner of the new token, which is not necessarily whoever asked for it
+        -- a sysadmin can mint tokens for other accounts, and that is exactly
+        the case worth being able to see. Both are recorded.
+        """
+        # ``data`` is on its way into the encoder, so this runs on the critical
+        # path of minting a token. Nothing here may raise: failing to record an
+        # issuance is bad, failing to issue is worse.
+        try:
+            actor = toolkit.current_user if has_request_context() else None
+            emit_audit_log(
+                action="api_token_issued",
+                status="success",
+                user_name=_safe_attr(actor, "name"),
+                user_id=_safe_attr(actor, "id"),
+                message="API token {} issued for user {}".format(
+                    jti, data_dict.get("user", "unknown")
+                ),
+                token_id=jti,
+                token_name=data_dict.get("name"),
+                token_owner=data_dict.get("user"),
+            )
+        except Exception:
+            log.exception("Failed to emit API token issuance audit log")
+        return data


### PR DESCRIPTION
Extends `sse_audit` from authentication events to the action API, so a token can be followed from issuance, through every call it makes, to its revocation. Same stdout channel and same event shape as the existing auth events — nothing new to register, `sse_audit` is already in the plugin list.

## Events

| action | hook | key fields |
|---|---|---|
| `api_token_issued` | `IApiToken.postprocess_api_token` | `token_id`, `token_name`, `token_owner`, actor in `user_name` |
| `api_token_revoked` | `action_succeeded` / sender `api_token_revoke` | `token_id`, `revoked_by` |
| `api_request` | `request_finished` | `api_action`, `params`, `token_id`, `token_auth`, `http_status`, `http_method` |

`token_id` is the same jti throughout, so the three join on one field.

## Why these hooks

`postprocess_api_token` is the only hook handed the token id. `action_succeeded` is no use for issuance: its `result` is `{"token": <raw secret>}` and carries no id.

`api_request` comes from `request_finished`, not `action_succeeded`, because the latter only fires on success — and a `NotAuthorized`, or a token that fails to decode, is exactly the event an audit trail exists to record.

## token_auth

Classifies every call as `token`, `token_revoked`, `token_invalid`, `session` or `anonymous`.

`token_revoked` is the one worth calling out. A revoked token still decodes — validly signed, unexpired — so only the missing `ApiToken` row reveals it is dead. Without a distinct class it is indistinguishable from a live token, and the response is an ordinary anonymous 200 on any endpoint permitting anonymous reads. This was caught in live testing, not review.

## Scope

The action API alone: `/api/3/action/<name>` and the unversioned `/api/action/<name>`. The rest of the `/api` blueprint — root version doc, autocompletes, snippet fetcher, i18n bundle — is browser plumbing pulled by every page load and is excluded.

Matched on the `logic_function` **view argument**, not the endpoint or blueprint name. Those are not stable here: `ckanext-googleanalytics` re-registers both action URL rules under its own blueprint, so on this deployment the endpoint is `google_analytics.action`, not `api.action`. An earlier `request.blueprint == "api"` check was silently dead for that reason.

## Two hazards handled

**Secrets in params.** `user_update` carries `password`, `api_token_revoke` carries the raw token. Redacted by key name — audit output reaches a log store with a much wider reader set than the database. Config: `ckanext.sse.audit.redacted_params`.

**Line size.** A line long enough to be chopped by the collector arrives as invalid JSON and takes its own event with it, so a large `datastore_upsert` would erase the record of itself. Values trim individually; if still over budget, values drop and key names survive. Config: `ckanext.sse.audit.max_param_value` (512), `max_params_bytes` (4096).

## A bug this change had to fix in itself

The `request_finished` receiver originally did its work outside the `try/except`. When an action fails CKAN rolls the session back, leaving `current_user` detached; reading `.name` then raises `DetachedInstanceError`. `finalize_request` does not guard its own signal, so **the audit hook replaced CKAN's 409 with a 500**.

Now the whole receiver is inside the boundary, and every ORM read goes through `_safe_attr` — including the pre-existing login/logout paths, which had the same latent hazard. `postprocess_api_token` is wrapped too, since it sits on the critical path of minting a token: failing to log an issuance must never become failing to issue one.

Only reachable when an action fails *and* a user is attached, which is why the happy-path testing missed it.

## Testing

`./audit-smoke.sh` drives the full lifecycle against a local dev CKAN and asserts on what was emitted — 12 checks including redaction, the four `token_auth` classifications, the 409-not-500 regression, and a negative check that nothing outside the action API is logged. Verified against CKAN 2.10 in the dev compose stack.

Also exercised via a stub harness (34 assertions) covering both truncation paths and the override-blueprint case; not included here, as the repo's `test.ini` cannot resolve CKAN core so there is nowhere for it to live yet. Landing real pytest cases is the natural follow-up.

## Known limits

- Requests that 500 produce no line — `request_finished` does not fire when an exception escapes CKAN's handlers.
- Actions CKAN's own server-rendered UI invokes (`/dataset/new` and friends) are out of scope; they never reach `/api`. The SSEN portal frontend *is* covered, since it calls the action API over HTTP.
- On rolled-back requests `user_name` reads `anonymous` even with `token_auth: token`; `token_id` still identifies the caller.

## Unrelated, noted

CKAN 2.10 logs the **full** API token at DEBUG in `ckan/views/__init__.py:137` (2.11 truncates to 10 chars). If prod runs at DEBUG, live tokens are already in the logs. Not addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded security audit logging to cover API requests, token issuance, revocation, authentication outcomes, statuses, and network context.
  * Added safeguards to redact sensitive request parameters and limit logged values.
  * Added auditing for token-based access, anonymous requests, invalid tokens, and revoked tokens.
* **Bug Fixes**
  * Audit logging failures no longer interrupt API requests.
* **Tests**
  * Added an end-to-end smoke test covering API auditing, token lifecycle behavior, access controls, redaction, and out-of-scope requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->