### PR TITLE
feat(reuses): let anyone read approved submissions, redact submitter PII

### DIFF
--- a/ckanext/sse/action.py
+++ b/ckanext/sse/action.py
@@ -676,6 +676,62 @@ def data_reuse_create(context, data_dict):
         raise tk.ValidationError(f"Failed to create data reuse submission: {str(e)}")
 
 
+PUBLIC_REUSE_DATA_FIELDS = (
+    "title",
+    "description",
+    "label",
+    "image_url",
+    "organisation_name",
+    "dashboard_url",
+)
+
+
+def _is_reuse_moderator(context):
+    """
+    Whether the caller moderates data reuse submissions.
+
+    Moderators see submissions in full - everyone else gets the public fields.
+    Internal calls (ignore_auth) count as moderators.
+    """
+    if context.get("ignore_auth"):
+        return True
+
+    user = context.get("auth_user_obj")
+
+    return bool(user and not user.is_anonymous and user.sysadmin)
+
+
+def _public_reuse_dict(submission_dict):
+    """
+    Drop the submitter's personal details from a submission.
+
+    The submission `data` is free-form JSONB holding both the fields the
+    portal renders and the ones only moderators should see (email address,
+    name, job title, contact preferences), so allowlist the public ones
+    rather than denylisting the rest.
+    """
+    data = submission_dict.get("data") or {}
+    public_data = {k: v for k, v in data.items() if k in PUBLIC_REUSE_DATA_FIELDS}
+
+    if not asbool(data.get("visible_org_permission") or False):
+        public_data["organisation_name"] = None
+
+    submission_dict["data"] = public_data
+    submission_dict.pop("user_id", None)
+
+    return submission_dict
+
+
+def _reuse_dataset_dict(context, package_id):
+    """
+    The dataset a submission points at, or None when the caller cannot see it.
+    """
+    try:
+        return tk.get_action("package_show")(context, {"id": package_id})
+    except (tk.NotAuthorized, tk.ObjectNotFound):
+        return None
+
+
 @tk.side_effect_free
 def data_reuse_list(context, data_dict):
     """
@@ -708,13 +764,16 @@ def data_reuse_list(context, data_dict):
 
     total_count = len(submissions)
     submissions = submissions[offset : offset + limit]
+    is_moderator = _is_reuse_moderator(context)
     result = []
     for submission in submissions:
         submission_dict = submission.as_dict()
+        if not is_moderator:
+            submission_dict = _public_reuse_dict(submission_dict)
         if include_dataset and submission.package_id:
-            submission_dict["dataset"] = tk.get_action("package_show")(
-                context, {"id": submission.package_id}
-            )
+            dataset = _reuse_dataset_dict(context, submission.package_id)
+            if dataset is not None:
+                submission_dict["dataset"] = dataset
         result.append(submission_dict)
 
     return {
@@ -744,10 +803,12 @@ def data_reuse_show(context, data_dict):
         raise tk.ObjectNotFound("Data reuse submission not found")
 
     submission_dict = submission.as_dict()
+    if not _is_reuse_moderator(context):
+        submission_dict = _public_reuse_dict(submission_dict)
     if include_dataset and submission.package_id:
-        submission_dict["dataset"] = tk.get_action("package_show")(
-            context, {"id": submission.package_id}
-        )
+        dataset = _reuse_dataset_dict(context, submission.package_id)
+        if dataset is not None:
+            submission_dict["dataset"] = dataset
     return submission_dict
 
 
@@ -811,9 +872,21 @@ def data_reuse_patch(context, data_dict):
     id = tk.get_or_bust(data_dict, "id")
     feedback = data_dict.get("feedback")
 
-    existing_dict = tk.get_action("data_reuse_show")(
-        context, {"id": id, "include_all": True}
-    )
+    # Submitters may patch their own submission, but moderating one - approving
+    # or rejecting it - stays with sysadmins.
+    if "state" in data_dict and not _is_reuse_moderator(context):
+        raise tk.NotAuthorized(
+            _("Only sysadmins can change the state of a data reuse submission")
+        )
+
+    submission = FormResponse.get(id, include_all=True)
+    if not submission:
+        raise tk.ObjectNotFound("Data reuse submission not found")
+
+    # Read the row itself rather than going through data_reuse_show: the patched
+    # dict is written straight back to the database, and a redacted read would
+    # erase the submitter's details.
+    existing_dict = submission.as_dict()
     patched_dict = dict(existing_dict)
     patched_dict.update(data_dict)
 

--- a/ckanext/sse/auth.py
+++ b/ckanext/sse/auth.py
@@ -8,7 +8,9 @@ from .model import FormResponse
 def data_reuse_create(context, data_dict):
     """
     Authorization for creating data reuse submissions (examples or ideas).
-    Anonymous users are allowed to submit data reuse examples and ideas.
+
+    Any authenticated user may submit data reuse examples and ideas.
+    Anonymous users are not allowed.
     """
     user = context.get('user')
     if not user:
@@ -26,37 +28,49 @@ def data_reuse_update(context, data_dict):
     user = context.get('user')
     if not user:
         return {'success': False, 'msg': 'User not authenticated'}
-    
-    # Get the submission to check ownership
+
+    # Get the submission to check ownership. Look it up in any state - a
+    # submitter's own submission is usually still pending.
     submission_id = data_dict.get('id')
-    if submission_id:
+    user_obj = context.get('auth_user_obj')
+    if submission_id and user_obj:
         try:
-            submission = FormResponse.get(submission_id)
-            if submission and submission.user_id == context.get('auth_user_obj').id:
+            submission = FormResponse.get(submission_id, include_all=True)
+            if submission and submission.user_id == user_obj.id:
                 return {'success': True}
-        except:
+        except Exception:
             pass
-    
-    # Fall back to sysadmin check
-    return tk.auth_sysadmins_check(context, data_dict)
+
+    # Anyone else is denied; sysadmins bypass this check.
+    return {'success': False}
 
 
 def data_reuse_list(context, data_dict):
     """
     Authorization for listing data reuse submissions.
-    
-    Only sysadmins can list data reuse submissions.
+
+    Anyone may list approved submissions; the action redacts submitter
+    details for non-sysadmins. Listing submissions in any other state
+    (include_all) stays sysadmin-only.
     """
-    return {'success': False}
+    if tk.asbool(data_dict.get('include_all', False)):
+        return {'success': False}
+
+    return {'success': True}
 
 
 def data_reuse_show(context, data_dict):
     """
     Authorization for showing a specific data reuse submission.
-    
-    Only sysadmins can view individual submissions.
+
+    Anyone may view an approved submission; the action redacts submitter
+    details for non-sysadmins. Viewing a submission in any other state
+    (include_all) stays sysadmin-only.
     """
-    return {'success': False}
+    if tk.asbool(data_dict.get('include_all', False)):
+        return {'success': False}
+
+    return {'success': True}
 
 def data_reuse_delete(context, data_dict):
     """

--- a/ckanext/sse/auth.py
+++ b/ckanext/sse/auth.py
@@ -1,8 +1,12 @@
 """
 Authorization functions for form submissions and usage ideas.
 """
+from logging import getLogger
+
 import ckan.plugins.toolkit as tk
 from .model import FormResponse
+
+log = getLogger(__name__)
 
 
 def data_reuse_create(context, data_dict):
@@ -39,12 +43,16 @@ def data_reuse_update(context, data_dict):
             if submission and submission.user_id == user_obj.id:
                 return {'success': True}
         except Exception:
-            pass
+            log.exception(
+                'Could not check ownership of data reuse submission %s',
+                submission_id,
+            )
 
     # Anyone else is denied; sysadmins bypass this check.
     return {'success': False}
 
 
+@tk.auth_allow_anonymous_access
 def data_reuse_list(context, data_dict):
     """
     Authorization for listing data reuse submissions.
@@ -59,6 +67,7 @@ def data_reuse_list(context, data_dict):
     return {'success': True}
 
 
+@tk.auth_allow_anonymous_access
 def data_reuse_show(context, data_dict):
     """
     Authorization for showing a specific data reuse submission.

--- a/ckanext/sse/blueprints/data_reuse.py
+++ b/ckanext/sse/blueprints/data_reuse.py
@@ -157,7 +157,9 @@ def list_data_reuse():
     context = _get_context()
 
     try:
-        tk.check_access("data_reuse_list", context, {})
+        # This page lists submissions in every state, which is sysadmin-only -
+        # listing approved submissions alone is public.
+        tk.check_access("data_reuse_list", context, {"include_all": True})
     except tk.NotAuthorized:
         return tk.abort(403, tk._("Not authorized to view data reuse submissions"))
 

--- a/ckanext/sse/templates/data_reuse/data_reuse_widget.html
+++ b/ckanext/sse/templates/data_reuse/data_reuse_widget.html
@@ -14,7 +14,7 @@
         <i class="fa fa-edit"></i> {{ _('Share Data Usage Example') }}
       </a>
       
-      {% if h.check_access('data_reuse_list') %}
+      {% if h.check_access('data_reuse_list', {'include_all': True}) %}
         <a href="{{ h.url_for('data_reuse.list_data_reuse', package_id=pkg.id) }}" 
            class="btn btn-default">
           <i class="fa fa-list"></i> {{ _('View all reuse or idea') }}


### PR DESCRIPTION
Reading data reuse submissions required a sysadmin token, which forced the portal to call CKAN with a shared sysadmin API key just to render its public ideas and examples pages. Approved submissions are public content, so allow anonymous reads and redact instead.

data_reuse_list and data_reuse_show now succeed for any caller. Listing or showing submissions in any other state (include_all) stays sysadmin-only, so pending and rejected submissions remain private.

Non-moderator callers get an allowlisted projection of the submission data: title, description, label, image_url, organisation_name and dashboard_url. The submission data is free-form JSONB holding both the fields the portal renders and the submitter's email address, name, job title and contact preferences, so an allowlist is the only safe direction - a denylist would leak whatever field the next form revision adds. user_id is dropped too, and organisation_name is nulled unless the submitter allowed it to be shown, which the portal previously did itself after fetching the full record.

A linked dataset is now resolved per caller, so a submission pointing at a dataset the caller cannot see omits the dataset rather than failing the whole list.

Two gates needed updating to keep the moderation UI sysadmin-only, since both asked whether the caller may list submissions at all: the /dataset/reuse list view and the "View all reuse or idea" link in the package widget. Both now ask about include_all.

Also fixes three pre-existing problems on the same paths:

- data_reuse_patch merges what it reads back into the row and writes it with FormResponse.update, which setattrs data wholesale. Reading through data_reuse_show would therefore have erased the submitter's details on every approval, so it now reads the row directly.
- data_reuse_update authorization allows a submission's owner, and data_reuse_patch accepts arbitrary keys including state, so owners could have approved their own submissions once the read above stopped failing. State changes are now sysadmin-only.
- data_reuse_update authorization looked submissions up with the default approved-only filter, so an owner never matched their own pending submission, and its sysadmin fallback called auth_sysadmins_check with two arguments when it is a decorator, raising TypeError - every non-owner got a 500 instead of a 403.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Privacy**
  - Submitter details are limited to approved public fields for non-moderators.
  - Organization names may be hidden when appropriate.
  - Moderators and authorized internal operations retain complete submission details.

- **Access Control**
  - Authentication is required to create data reuse submissions.
  - Only moderators can change submission status.
  - Owners can update their submissions; unauthorized requests remain blocked.
  - Approved submissions remain publicly viewable, while all-state listings require authorized administrators.

- **Bug Fixes**
  - Listings now handle unavailable or unauthorized datasets without failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->