### PR TITLE
Restrict datastore SQL search to authenticated users and audit queries

### DIFF
--- a/ckanext/sse/action.py
+++ b/ckanext/sse/action.py
@@ -960,15 +960,9 @@ def datastore_search_sql(original_action, context, data_dict):
     """
     Reject anonymous callers before the query reaches the database.
 
-    The chained auth function is not enough on its own. CKAN only reaches it
-    through ``check_access``, which ``search_sql`` calls *after*
-    ``get_table_and_function_names_from_sql`` has already run
-    ``EXPLAIN (VERBOSE, FORMAT JSON)`` on the submitted SQL, so an anonymous
-    caller could read planner errors back and probe for tables and columns.
-
-    ``side_effect_free`` is re-declared because chaining copies only this
-    function's attributes onto the partial CKAN builds, and the portal calls
-    this over GET.
+    The auth function is not enough: ``check_access`` runs after
+    ``search_sql`` has already EXPLAINed the SQL, so anonymous callers could
+    probe for tables and columns through planner errors.
     """
     user_obj = context.get('auth_user_obj')
     anonymous = user_obj is None or getattr(user_obj, 'is_anonymous', False)

--- a/ckanext/sse/action.py
+++ b/ckanext/sse/action.py
@@ -952,3 +952,30 @@ def resources_stats(context, data_dict):
         counts[key] = int(cnt)
 
     return counts
+
+
+@tk.chained_action
+@tk.side_effect_free
+def datastore_search_sql(original_action, context, data_dict):
+    """
+    Reject anonymous callers before the query reaches the database.
+
+    The chained auth function is not enough on its own. CKAN only reaches it
+    through ``check_access``, which ``search_sql`` calls *after*
+    ``get_table_and_function_names_from_sql`` has already run
+    ``EXPLAIN (VERBOSE, FORMAT JSON)`` on the submitted SQL, so an anonymous
+    caller could read planner errors back and probe for tables and columns.
+
+    ``side_effect_free`` is re-declared because chaining copies only this
+    function's attributes onto the partial CKAN builds, and the portal calls
+    this over GET.
+    """
+    user_obj = context.get('auth_user_obj')
+    anonymous = user_obj is None or getattr(user_obj, 'is_anonymous', False)
+
+    if anonymous and not context.get('user'):
+        raise tk.NotAuthorized(
+            _('datastore_search_sql is available to authenticated users only')
+        )
+
+    return original_action(context, data_dict)

--- a/ckanext/sse/audit.py
+++ b/ckanext/sse/audit.py
@@ -140,8 +140,7 @@ token api_token apikey api_key key secret client_secret
 DEFAULT_MAX_PARAM_VALUE = 512
 DEFAULT_MAX_PARAMS = 4096
 
-# Thresholds for tagging a SQL query in the audit trail. Neither rejects
-# anything; they exist so alerting can filter on ``flags``.
+# Tagging thresholds only -- nothing is rejected, alerting filters on ``flags``.
 DEFAULT_SLOW_QUERY_MS = 5000
 DEFAULT_LARGE_RESULT_ROWS = 10000
 
@@ -604,13 +603,7 @@ def _client_ip(forwarded_for, remote_addr, cdn_client_ip=None):
 @toolkit.chained_action
 @toolkit.side_effect_free
 def datastore_search_sql(original_action, context, data_dict):
-    """Record each SQL query: who ran it, how long it took, how much it
-    returned, and why it failed.
-
-    ``side_effect_free`` is re-declared because chaining copies only this
-    function's attributes onto the partial CKAN builds, and the portal calls
-    this over GET.
-    """
+    """Record each SQL query: who, how long, how much, and why it failed."""
     started = time.monotonic()
     try:
         result = original_action(context, data_dict)
@@ -656,8 +649,7 @@ def _log_sql_query(context, data_dict, started, result=None, error=None):
             ),
             sql=_trim_value(sql),
             sql_chars=len(sql),
-            # Groups repeats of one query -- a scripted sweep, a retry loop --
-            # without depending on the trimmed text.
+            # Groups repeats of one query without relying on trimmed text.
             sql_fingerprint=hashlib.sha256(
                 " ".join(sql.split()).encode("utf-8")
             ).hexdigest()[:16],
@@ -717,9 +709,8 @@ class SecurityAuditPlugin(plugins.SingletonPlugin):
 
     # IActions
     def get_actions(self):
-        # Registered only when the action exists: chaining onto a missing
-        # action raises at startup, and ``ckanext.datastore`` withholds
-        # ``datastore_search_sql`` unless sqlsearch is enabled.
+        # Chaining onto a missing action raises at startup, and datastore
+        # withholds this one unless sqlsearch is enabled.
         if not toolkit.asbool(
             toolkit.config.get("ckan.datastore.sqlsearch.enabled", False)
         ):

--- a/ckanext/sse/audit.py
+++ b/ckanext/sse/audit.py
@@ -59,11 +59,13 @@ environment, both measured rather than assumed:
 """
 
 import datetime
+import hashlib
 import ipaddress
 import json
 import logging
 import re
 import sys
+import time
 
 from flask import g, has_request_context
 from flask_login import user_logged_in
@@ -137,6 +139,11 @@ token api_token apikey api_key key secret client_secret
 # survive, which is the part that matters for an audit trail anyway.
 DEFAULT_MAX_PARAM_VALUE = 512
 DEFAULT_MAX_PARAMS = 4096
+
+# Thresholds for tagging a SQL query in the audit trail. Neither rejects
+# anything; they exist so alerting can filter on ``flags``.
+DEFAULT_SLOW_QUERY_MS = 5000
+DEFAULT_LARGE_RESULT_ROWS = 10000
 
 
 def get_subscriptions():
@@ -594,6 +601,77 @@ def _client_ip(forwarded_for, remote_addr, cdn_client_ip=None):
     return chain[index]
 
 
+@toolkit.chained_action
+@toolkit.side_effect_free
+def datastore_search_sql(original_action, context, data_dict):
+    """Record each SQL query: who ran it, how long it took, how much it
+    returned, and why it failed.
+
+    ``side_effect_free`` is re-declared because chaining copies only this
+    function's attributes onto the partial CKAN builds, and the portal calls
+    this over GET.
+    """
+    started = time.monotonic()
+    try:
+        result = original_action(context, data_dict)
+    except Exception as error:
+        _log_sql_query(context, data_dict, started, error=error)
+        raise
+
+    _log_sql_query(context, data_dict, started, result=result)
+    return result
+
+
+def _log_sql_query(context, data_dict, started, result=None, error=None):
+    try:
+        duration_ms = int((time.monotonic() - started) * 1000)
+        sql = data_dict.get("sql") or ""
+        records = (result or {}).get("records") or []
+        truncated = bool((result or {}).get("records_truncated"))
+
+        flags = []
+        if duration_ms >= _int_config(
+            "ckanext.sse.audit.slow_query_ms", DEFAULT_SLOW_QUERY_MS
+        ):
+            flags.append("slow")
+        if len(records) >= _int_config(
+            "ckanext.sse.audit.large_result_rows", DEFAULT_LARGE_RESULT_ROWS
+        ):
+            flags.append("large")
+        if truncated:
+            flags.append("truncated")
+
+        emit_audit_log(
+            action="datastore_sql_query",
+            status="failure" if error else "success",
+            user_name=context.get("user") or None,
+            user_id=_safe_attr(context.get("auth_user_obj"), "id"),
+            message="Datastore SQL query {} in {}ms, {} rows".format(
+                "failed" if error else "ran", duration_ms, len(records)
+            ),
+            token_id=(
+                getattr(g, TOKEN_ID_ATTR, None)
+                if has_request_context()
+                else None
+            ),
+            sql=_trim_value(sql),
+            sql_chars=len(sql),
+            # Groups repeats of one query -- a scripted sweep, a retry loop --
+            # without depending on the trimmed text.
+            sql_fingerprint=hashlib.sha256(
+                " ".join(sql.split()).encode("utf-8")
+            ).hexdigest()[:16],
+            duration_ms=duration_ms,
+            row_count=len(records),
+            records_truncated=truncated,
+            flags=flags,
+            error_class=type(error).__name__ if error else None,
+            error_message=_trim_value(str(error)) if error else None,
+        )
+    except Exception:
+        log.exception("Failed to emit datastore SQL audit log")
+
+
 def emit_audit_log(action, status, message, user_name=None, user_id=None,
                    **extra):
     # A broken audit line must never break the request it describes. These
@@ -631,10 +709,22 @@ class SecurityAuditPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IAuthenticator, inherit=True)
     plugins.implements(plugins.ISignal)
     plugins.implements(plugins.IApiToken, inherit=True)
+    plugins.implements(plugins.IActions)
 
     # ISignal
     def get_signal_subscriptions(self):
         return get_subscriptions()
+
+    # IActions
+    def get_actions(self):
+        # Registered only when the action exists: chaining onto a missing
+        # action raises at startup, and ``ckanext.datastore`` withholds
+        # ``datastore_search_sql`` unless sqlsearch is enabled.
+        if not toolkit.asbool(
+            toolkit.config.get("ckan.datastore.sqlsearch.enabled", False)
+        ):
+            return {}
+        return {"datastore_search_sql": datastore_search_sql}
 
     # IAuthenticator
     def logout(self):

--- a/ckanext/sse/auth.py
+++ b/ckanext/sse/auth.py
@@ -88,3 +88,32 @@ def data_reuse_delete(context, data_dict):
     Only sysadmins can delete submissions.
     """
     return {'success': False}
+
+
+@tk.chained_auth_function
+def datastore_search_sql(next_auth, context, data_dict):
+    """
+    Restrict ``datastore_search_sql`` to authenticated users.
+
+    Chained because ``ckanext.datastore`` already registers this name and
+    ``ckan/authz.py`` raises if two plugins claim one non-chained.
+
+    Omitting ``@tk.auth_allow_anonymous_access`` is not enough on its own:
+    ``is_authorized`` gates on ``auth_user_obj`` being absent, but the action
+    API sets it to flask-login's ``AnonymousUser`` (``ckan/views/api.py``),
+    which is truthy. Hence the explicit check, which reads ``is_anonymous``
+    rather than truthiness. ``user`` is still honoured so internal calls that
+    pass only a name keep working.
+    """
+    user_obj = context.get('auth_user_obj')
+    anonymous = user_obj is None or getattr(user_obj, 'is_anonymous', False)
+
+    if anonymous and not context.get('user'):
+        return {
+            'success': False,
+            'msg': tk._(
+                'datastore_search_sql is available to authenticated users only'
+            ),
+        }
+
+    return next_auth(context, data_dict)

--- a/ckanext/sse/auth.py
+++ b/ckanext/sse/auth.py
@@ -95,15 +95,9 @@ def datastore_search_sql(next_auth, context, data_dict):
     """
     Restrict ``datastore_search_sql`` to authenticated users.
 
-    Chained because ``ckanext.datastore`` already registers this name and
-    ``ckan/authz.py`` raises if two plugins claim one non-chained.
-
-    Omitting ``@tk.auth_allow_anonymous_access`` is not enough on its own:
-    ``is_authorized`` gates on ``auth_user_obj`` being absent, but the action
-    API sets it to flask-login's ``AnonymousUser`` (``ckan/views/api.py``),
-    which is truthy. Hence the explicit check, which reads ``is_anonymous``
-    rather than truthiness. ``user`` is still honoured so internal calls that
-    pass only a name keep working.
+    Chained because ``ckanext.datastore`` registers this name too. Checks
+    ``is_anonymous`` rather than truthiness: the action API sets
+    ``auth_user_obj`` to flask-login's ``AnonymousUser``, which is truthy.
     """
     user_obj = context.get('auth_user_obj')
     anonymous = user_obj is None or getattr(user_obj, 'is_anonymous', False)

--- a/ckanext/sse/plugin.py
+++ b/ckanext/sse/plugin.py
@@ -221,7 +221,7 @@ class SsePlugin(plugins.SingletonPlugin):
 
     # IActions
     def get_actions(self):
-        return {
+        actions = {
             "package_create": action.package_create,
             "resource_activity_list": action.resource_activity_list,
             "package_collaborator_create": action.package_collaborator_create,
@@ -242,6 +242,15 @@ class SsePlugin(plugins.SingletonPlugin):
             "data_reuse_delete": action.data_reuse_delete,
             "resources_stats": action.resources_stats
         }
+
+        # Only when the action exists: chaining onto a missing one raises at
+        # startup, and ckanext.datastore withholds it unless sqlsearch is on.
+        if toolkit.asbool(
+            toolkit.config.get("ckan.datastore.sqlsearch.enabled", False)
+        ):
+            actions["datastore_search_sql"] = action.datastore_search_sql
+
+        return actions
 
     # IAuthFunctions
     def get_auth_functions(self):

--- a/ckanext/sse/plugin.py
+++ b/ckanext/sse/plugin.py
@@ -243,8 +243,8 @@ class SsePlugin(plugins.SingletonPlugin):
             "resources_stats": action.resources_stats
         }
 
-        # Only when the action exists: chaining onto a missing one raises at
-        # startup, and ckanext.datastore withholds it unless sqlsearch is on.
+        # Chaining onto a missing action raises at startup, and datastore
+        # withholds this one unless sqlsearch is enabled.
         if toolkit.asbool(
             toolkit.config.get("ckan.datastore.sqlsearch.enabled", False)
         ):

--- a/ckanext/sse/plugin.py
+++ b/ckanext/sse/plugin.py
@@ -251,6 +251,7 @@ class SsePlugin(plugins.SingletonPlugin):
             "data_reuse_show": auth.data_reuse_show,
             "data_reuse_update": auth.data_reuse_update,
             "data_reuse_delete": auth.data_reuse_delete,
+            "datastore_search_sql": auth.datastore_search_sql,
         }
 
     # ISignal


### PR DESCRIPTION
Compensating controls for **SR0007564** (unauthenticated SQL injection in the CKAN datastore), per datopian/client-sse-networks-shared#324.

SQL search stays enabled — the portal's data explorer and chart builder depend on it.

## What this does

**1. Restricts `datastore_search_sql` to authenticated users.** Enforced in a chained *action* that raises `NotAuthorized` before delegating, plus a chained auth function.

**2. Audits every SQL query.** A `datastore_sql_query` event through the existing `sse_audit` pipeline: user, token id, client IP, trimmed SQL, a fingerprint for grouping repeats, duration, row count, truncation, and error class/message on failure. Slow and large results are tagged in `flags` for alerting. Thresholds label only, they never reject.

The function whitelist (item 2 of the issue) is configuration and lives in the deployment repos — see the companion PRs.

## Why two layers, not just the auth function

An auth function alone is **not** a real gate here. CKAN only reaches it via `check_access`, which `search_sql` calls *after* it has already run `EXPLAIN (VERBOSE, FORMAT JSON)` on the submitted SQL:

```python
table_names, function_names = get_names(context, sql)   # EXPLAIN runs
if any(t.startswith('pg_') for t in table_names): raise NotAuthorized
context['check_access'](table_names)                    # auth function runs HERE
```

With only the auth function in place, an anonymous caller could still get arbitrary SQL planned and read the errors back:

```
SELECT nosuchcol FROM "<res>"  -> 409 column "nosuchcol" does not exist
SELECT * FROM "user"           -> 409 relation "user" does not exist
```

That is pre-auth schema reconnaissance. The action guard closes it; anonymous now gets an identical 403 for any SQL, valid or not.

## CKAN 2.10 details worth reviewing

- **Chaining is forced.** `datastore_search_sql` is registered by the `datastore` plugin, not core, so a plain override makes `sse` the second plugin to claim it and `ckan/authz.py:_build` raises `The auth function ... is already implemented`. Verified: it fails *lazily* on first auth lookup, and takes the whole action API down with it (`status_show` -> 500), not just this endpoint.
- **Omitting `@auth_allow_anonymous_access` is not sufficient.** `is_authorized` denies anonymous by checking `auth_user_obj` is absent, but `ckan/views/api.py:245` sets it to flask-login's `AnonymousUser`, which is truthy — so the guard never fires on the API path. Both checks test `is_anonymous` explicitly.
- **`@side_effect_free` is re-declared** on the chained actions: CKAN copies only the chaining function's `__dict__` onto the partial it builds, and the portal calls this over GET.
- **Registration is conditional** on `ckan.datastore.sqlsearch.enabled`, because chaining onto an action the datastore withholds raises at startup.

## Verified against a local CKAN 2.10.6

```
--- anonymous
invalid column       http=403  datastore_search_sql is available to authenticated users only
probe table          http=403  datastore_search_sql is available to authenticated users only
valid query          http=403  datastore_search_sql is available to authenticated users only
--- authenticated
valid query          http=200  [{'count': 1475}]
invalid column       http=409  column "nosuchcol" does not exist
blocked function     http=403  Not authorized to call function upper
aggregates           http=200  [{'sum': 1475, 'avg': '1.000...'}]
```

Every SQL shape the frontend can emit was also exercised against the whitelist — all six filter operators, sorting, pagination, `GROUP BY` with `SUM`/`AVG`/`COUNT`, mixed case — all pass.

## Notes for review

- Anonymous denials are recorded as `api_request` failures (with the attempted SQL, status 403, source IP), not as `datastore_sql_query` — the action guard sits outside the audit wrapper in the chain. Say if you want the richer event on denials too.
- No tests. `test.ini` points at a path that does not resolve under the dev container layout, so the suite cannot run; this is pre-existing and called out in the repo's known gaps.

## Deploy

Requires the pinned SHA in `ckan/Dockerfile` of both helm repos to be bumped after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added access controls for datastore SQL searches, requiring authentication.
  * Added configurable auditing for SQL searches, including execution time, result size, truncation, query fingerprints, slow queries, and failures.
  * SQL search protections and auditing are enabled only when the feature is configured.

* **Bug Fixes**
  * Prevented anonymous requests from being processed or analyzed.
  * Blocked SQL searches containing write or schema-modifying operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->