### PR TITLE
[WIP] feat(auth): implement SSE IA-5 and AC-7/AC-2.3/AC-11 security standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,9 +240,22 @@ authenticated request rather than only at sign-in — an account making daily AP
 calls is plainly in use. Accounts that have never been active fall back to their
 creation date, so an account created 60 days ago and never used is caught.
 
-Sysadmins and the site user are exempt by default; the former stands in for
-AC-2.3's "Admin Disablement" groups, because a sweep that disables every
-administrator during a quiet month leaves nobody able to undo it.
+**Only privileged accounts are swept:** sysadmins, members, editors and admins
+of an organisation, and users made collaborators on a dataset. The control
+exists to shrink the set of standing privileged access paths, and a registered
+account with no organisation and no collaboration has read access to public
+data — which is what the portal offers anonymously anyway. Disabling those after
+45 days would churn ordinary data consumers without retiring any access.
+Organisation *members* are in scope despite the capacity being read-only,
+because membership carries access to that organisation's private datasets. Set
+`ckanext.sse.inactivity.privileged_only = false` to sweep every dormant account
+regardless.
+
+Sysadmins are in scope, since an idle sysadmin account is the most valuable one
+on the site. If a sweep ever disables the last active sysadmin,
+`ckan sysadmin add <name>` from a shell restores one — the recovery path is
+outside the web session the sweep can affect. The site user is always exempt,
+and `ckanext.sse.inactivity.exempt_users` names any others.
 
 There is no scheduler in a CKAN extension, so **this needs a cron entry or a
 Kubernetes CronJob** to satisfy "automatically disable":
@@ -270,7 +283,10 @@ not add a session write to every request.
 | `ckanext.sse.login.notify_lockout` | `true` | Email the account holder on lockout. |
 | `ckanext.sse.inactivity.idle_days` | `45` | Idle threshold for disablement. |
 | `ckanext.sse.inactivity.min_account_age_days` | `30` | Accounts younger than this are never disabled. |
-| `ckanext.sse.inactivity.exempt_sysadmins` | `true` | Leave sysadmins alone. |
+| `ckanext.sse.inactivity.privileged_only` | `true` | Sweep only accounts carrying privilege. |
+| `ckanext.sse.inactivity.capacities` | `admin editor member` | Membership capacities that count as privilege. |
+| `ckanext.sse.inactivity.include_collaborators` | `true` | Count dataset collaborations as privilege. |
+| `ckanext.sse.inactivity.exempt_sysadmins` | `false` | Leave sysadmins alone. |
 | `ckanext.sse.inactivity.exempt_users` | – | Further exempt account names, space separated. |
 | `ckanext.sse.session.idle_timeout_minutes` | `15` | Idle window before sign-out. `0` disables. |
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ A custom CKAN extension built specifically for the Scottish and Southern Electri
 - **Password Policy:**  
   Implements SSE’s IA-5 and IA-5.1 authentication standards: passphrase strength, no reuse of the last eight passwords, and rotation every 365 days (60 for sysadmins). See [Password policy](#password-policy).
 
+- **Access Control:**  
+  Implements SSE’s AC-7, AC-2.3 and AC-2.5/AC-11 standards: account lockout after six failed sign-ins, disablement of dormant accounts, and an idle session timeout. See [Access control](#access-control).
+
 ## Installation
 
 ### Prerequisites
@@ -157,10 +160,8 @@ is visible rather than assumed covered:
 - “not a single dictionary word” is only as good as the configured blocklist
   file; the built-in list covers common passwords, not the dictionary.
 
-Related controls in the same standards that this extension does **not**
-implement, and which need their own work: AC-7 (lock an account for 30 minutes
-after six consecutive failed logons), AC-2.3 (disable accounts after 45 days
-without a logon), and AC-2.5/AC-11 (idle session timeout).
+AC-7, AC-2.3 and AC-2.5/AC-11 are implemented separately — see
+[Access control](#access-control) below.
 
 ### Settings
 
@@ -187,6 +188,91 @@ without a logon), and AC-2.5/AC-11 (idle session timeout).
 policy rejects, so a bare `factories.User()` raises `ValidationError` while the
 plugin is enabled. Pass an explicit password — see
 `ckanext/sse/tests/test_password_policy.py`.
+
+## Access control
+
+Three further controls from SSE's *Standard for Access Control*, each in its
+own module and each documented there.
+
+### Account lockout (AC-7)
+
+Six consecutive failed sign-ins lock the account for 30 minutes. CKAN has no
+lockout of any kind on its own, so an account could be guessed at indefinitely.
+
+The mechanism follows `ckanext-security`: two Redis keys per account, a counter
+and a lock, each carrying its own expiry, so nothing has to be swept up
+afterwards and `INCR` stays atomic across workers. **Redis is required** —
+`ckan.redis.url` must point at a reachable instance. If it is unavailable the
+control fails *open*: the attempt is allowed and an error is logged, because a
+cache outage locking every user out of the portal is the worse failure.
+
+The lock is checked before CKAN's login view runs, so a correct password
+presented during the lockout does not shorten it. Attempts are counted from
+the `failed_login` signal rather than from `IAuthenticator.authenticate` — see
+the module docstring for why the obvious hook double-counts every failure —
+and only failures on the login endpoint count, so mistyping your current
+password on the profile form cannot lock you out.
+
+Counting is keyed on the account, resolved through the user table so a username
+and an email address share one budget. An attempt against a login matching no
+account is counted under what was typed, so spraying invented names gets no
+free ride either. The cost of account-keyed lockout is that a third party can
+lock a known account out by failing six times; that is inherent in the control,
+and the 30-minute expiry bounds it.
+
+Lockouts are recorded in the audit trail as `user_lockout` and, by default,
+emailed to the account holder — they are the one person who can tell an attack
+from their own typo.
+
+```
+ckan sse login-status <login>   # failure count and remaining lock time
+ckan sse unlock-login <login>   # the "or until released by an administrator" half
+```
+
+### Dormant account disablement (AC-2.3)
+
+Accounts idle for more than 45 days, and older than 30 days, are disabled.
+"Disabled" is CKAN's `deleted` state: the account cannot sign in and a sysadmin
+can restore it from the user edit form. Nothing is destroyed.
+
+Idle is measured from `user.last_active`, which CKAN stamps on every
+authenticated request rather than only at sign-in — an account making daily API
+calls is plainly in use. Accounts that have never been active fall back to their
+creation date, so an account created 60 days ago and never used is caught.
+
+Sysadmins and the site user are exempt by default; the former stands in for
+AC-2.3's "Admin Disablement" groups, because a sweep that disables every
+administrator during a quiet month leaves nobody able to undo it.
+
+There is no scheduler in a CKAN extension, so **this needs a cron entry or a
+Kubernetes CronJob** to satisfy "automatically disable":
+
+```
+ckan sse disable-inactive-users --dry-run   # list what would go
+ckan sse disable-inactive-users             # do it
+```
+
+### Idle session timeout (AC-2.5, AC-11)
+
+A signed-in session idle for 15 minutes is ended and the user must sign in
+again. AC-11 is written for a workstation lock, which a portal cannot do; ending
+the session is the compensating control. Anonymous browsing and the action API
+are unaffected. The activity stamp is only rewritten once a minute, so this does
+not add a session write to every request.
+
+### Settings
+
+| Setting | Default | Effect |
+| --- | --- | --- |
+| `ckanext.sse.login.max_attempts` | `6` | Failures before the account locks. |
+| `ckanext.sse.login.lockout_minutes` | `30` | How long the lock lasts. |
+| `ckanext.sse.login.attempt_window_minutes` | `30` | How long a failure is remembered. |
+| `ckanext.sse.login.notify_lockout` | `true` | Email the account holder on lockout. |
+| `ckanext.sse.inactivity.idle_days` | `45` | Idle threshold for disablement. |
+| `ckanext.sse.inactivity.min_account_age_days` | `30` | Accounts younger than this are never disabled. |
+| `ckanext.sse.inactivity.exempt_sysadmins` | `true` | Leave sysadmins alone. |
+| `ckanext.sse.inactivity.exempt_users` | – | Further exempt account names, space separated. |
+| `ckanext.sse.session.idle_timeout_minutes` | `15` | Idle window before sign-out. `0` disables. |
 
 ## Usage
 
@@ -222,6 +308,17 @@ database:
 
 ```bash
 pytest --ckan-ini /path/to/your-test.ini ckanext/sse/tests
+```
+
+That ini also needs `ckan.redis.url` pointing at a reachable Redis, since the
+AC-7 lockout state lives there and `test-core.ini` leaves it at `localhost`:
+
+```ini
+[app:main]
+use = config:/srv/app/src/ckan/test-core.ini
+ckan.plugins = sse
+sqlalchemy.url = postgresql://<user>:<password>@db/ckan_test
+ckan.redis.url = redis://redis:6379/1
 ```
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ A custom CKAN extension built specifically for the Scottish and Southern Electri
 - **Signal Subscriptions:**  
   Integrates with CKAN’s signal system to extend or modify behavior at key events during the dataset lifecycle.
 
+- **Password Policy:**  
+  Replaces CKAN’s 8-character password rule with a strength policy, blocks reuse of previous passwords, and forces rotation on a fixed window. See [Password policy](#password-policy).
+
 ## Installation
 
 ### Prerequisites
@@ -81,6 +84,66 @@ pip install -e .
    ckanext.dcat.base_uri = http://your-ckan-instance-url
    ```
 
+## Password policy
+
+Implemented in `ckanext/sse/password_policy.py`, which documents the reasoning
+behind each hook. Three controls, all optional to configure and all on by
+default:
+
+**Strength.** CKAN’s only rule is “8 characters or longer”. This extension
+replaces its `user_password_validator`, so the policy applies everywhere a
+password is set — registration, the profile form, the forgotten-password
+reset, and `user_create`/`user_update` over the API. A password must:
+
+- be between 12 and 128 characters long;
+- contain an uppercase letter, a lowercase letter, a digit and a symbol
+  (anything that is not a letter or a digit, including a space, so passphrases
+  are not pushed towards punctuation);
+- not repeat the same character three or more times in a row;
+- not contain four or more sequential characters (`1234`, `abcd`, `9876`);
+- not be based on a common password — checked with common character
+  substitutions undone, so `P@ssw0rd!` is rejected along with `Password123`;
+- not contain the user’s username, full name or email address.
+
+The rules are rendered next to every password field from
+`h.sse_password_policy_rules()`, so the hint cannot drift from what is
+enforced.
+
+**Reuse.** Every password a user has held is recorded as a hash in the
+`user_password_history` table, and a new password is verified against the
+retained ones. The current password always counts, whatever the history length
+is set to. Rows past the configured length are deleted rather than kept.
+
+**Rotation.** Once a password is older than the window, the user is redirected
+to the profile form on any page request until they change it. Logout and the
+forgotten-password reset stay reachable, so the block is not a trap. The action
+API is exempt: an API token is a separate credential with its own lifecycle,
+and answering a JSON call with a redirect to an HTML form breaks the client
+rather than protecting anything.
+
+Nothing needs migrating and nobody is locked out on the day this ships: the
+history table is seeded from each user’s live password hash on their first
+request, which starts a full window for them. Later changes made outside the
+actions — `ckan user setpass`, for instance — are picked up the same way.
+
+### Settings
+
+| Setting | Default | Effect |
+| --- | --- | --- |
+| `ckanext.sse.password.min_length` | `12` | Minimum length. Floor of 8. |
+| `ckanext.sse.password.max_length` | `128` | Maximum length. Caps the cost of hashing an oversized submission. |
+| `ckanext.sse.password.history_length` | `5` | Previous passwords that may not be reused. `0` checks only the current one. |
+| `ckanext.sse.password.expiry_days` | `90` | Rotation window. `0` disables the block entirely. |
+| `ckanext.sse.password.warn_days` | `14` | How far ahead of expiry to warn, once per browser session. `0` disables. |
+| `ckanext.sse.password.extra_blocklist` | – | Extra words banned anywhere in a password, space or comma separated. |
+
+### Note for tests
+
+`factories.User` defaults to a ten-character `faker.password()`, which this
+policy rejects, so a bare `factories.User()` raises `ValidationError` while the
+plugin is enabled. Pass an explicit password — see
+`ckanext/sse/tests/test_password_policy.py`.
+
 ## Usage
 
 Once installed and configured, the extension integrates seamlessly with CKAN. Key behaviors include:
@@ -105,6 +168,16 @@ Tests ensure the extension’s functionality remains robust. To run the tests, e
 
 ```bash
 pytest
+```
+
+`test.ini` inherits `../ckan/test-core.ini`, which assumes CKAN’s source sits
+alongside this repository. In the Docker development environment, where CKAN
+lives at `/srv/app/src/ckan` and the extensions at `/srv/app/src_extensions`,
+point pytest at an ini that inherits the right path and uses the `ckan_test`
+database:
+
+```bash
+pytest --ckan-ini /path/to/your-test.ini ckanext/sse/tests
 ```
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A custom CKAN extension built specifically for the Scottish and Southern Electri
   Integrates with CKAN’s signal system to extend or modify behavior at key events during the dataset lifecycle.
 
 - **Password Policy:**  
-  Replaces CKAN’s 8-character password rule with a strength policy, blocks reuse of previous passwords, and forces rotation on a fixed window. See [Password policy](#password-policy).
+  Implements SSE’s IA-5 and IA-5.1 authentication standards: passphrase strength, no reuse of the last eight passwords, and rotation every 365 days (60 for sysadmins). See [Password policy](#password-policy).
 
 ## Installation
 
@@ -86,55 +86,99 @@ pip install -e .
 
 ## Password policy
 
-Implemented in `ckanext/sse/password_policy.py`, which documents the reasoning
-behind each hook. Three controls, all optional to configure and all on by
-default:
+Implements SSE’s *Standard for Identification and Authentication* IA-5 and
+IA-5.1 as far as a CKAN portal can. `ckanext/sse/password_policy.py` documents
+the reasoning behind each hook and maps every clause of the standard to the
+code that enforces it.
 
 **Strength.** CKAN’s only rule is “8 characters or longer”. This extension
 replaces its `user_password_validator`, so the policy applies everywhere a
 password is set — registration, the profile form, the forgotten-password
 reset, and `user_create`/`user_update` over the API. A password must:
 
-- be between 12 and 128 characters long;
-- contain an uppercase letter, a lowercase letter, a digit and a symbol
-  (anything that is not a letter or a digit, including a space, so passphrases
-  are not pushed towards punctuation);
-- not repeat the same character three or more times in a row;
-- not contain four or more sequential characters (`1234`, `abcd`, `9876`);
-- not be based on a common password — checked with common character
-  substitutions undone, so `P@ssw0rd!` is rejected along with `Password123`;
-- not contain the user’s username, full name or email address.
+- be at least 12 characters, or 15 for an administration account (a CKAN
+  sysadmin), up to a maximum of 128;
+- not repeat the same character more than four times in a row;
+- not contain ascending or descending sequences — three or more digits
+  (`123`, `4321`) or four or more letters (`abcd`);
+- not be a common, expected or compromised password — checked with common
+  character substitutions undone, so `P@ssw0rd!` is rejected along with
+  `Password123`;
+- not contain the user’s username, full name or email address;
+- not be a previous password with the number changed (`Welcome100` →
+  `Welcome101`).
+
+There is deliberately **no character-class requirement**. The standard prefers
+passphrases and recommends the “three random word” approach, and demanding an
+uppercase, a digit and a symbol works against both. Set
+`ckanext.sse.password.require_character_classes = true` for a deployment that
+wants one anyway.
 
 The rules are rendered next to every password field from
-`h.sse_password_policy_rules()`, so the hint cannot drift from what is
-enforced.
+`h.sse_password_policy_rules()`, which reads the same configuration the
+validator does, so the hint cannot drift from what is enforced. A sysadmin is
+shown the 15-character rule that will actually be applied to them.
+
+IA-5.1 a and b ask for a list of common, expected and compromised passwords
+that is “updated continually”, which a list baked into the source cannot be.
+Point `ckanext.sse.password.blocklist_file` at a file of one word per line — a
+compromised-password corpus, a dictionary, or both — and replacing it becomes a
+deployment step rather than a release. The file is re-read when its mtime
+changes, so no restart is needed. Entries are matched against the whole
+password rather than as substrings, so a corpus full of ordinary English words
+does not ban the passphrases the standard asks for.
 
 **Reuse.** Every password a user has held is recorded as a hash in the
-`user_password_history` table, and a new password is verified against the
-retained ones. The current password always counts, whatever the history length
-is set to. Rows past the configured length are deleted rather than kept.
+`user_password_history` table, and a new password is verified against the last
+eight. The current password always counts, whatever the history length is set
+to. Rows past the configured length are deleted rather than kept — they are old
+credentials, so retaining more than the check consults is a liability.
 
-**Rotation.** Once a password is older than the window, the user is redirected
-to the profile form on any page request until they change it. Logout and the
-forgotten-password reset stay reachable, so the block is not a trap. The action
-API is exempt: an API token is a separate credential with its own lifecycle,
-and answering a JSON call with a redirect to an HTML form breaks the client
-rather than protecting anything.
+**Rotation.** 365 days for ordinary users and 60 for sysadmins, per IA-5 f.
+Past the window the user is redirected to the profile form on any page request
+until they change their password. Logout and the forgotten-password reset stay
+reachable, so the block is not a trap. The action API is exempt: an API token is
+a separate credential with its own lifecycle, and answering a JSON call with a
+redirect to an HTML form breaks the client rather than protecting anything.
 
 Nothing needs migrating and nobody is locked out on the day this ships: the
 history table is seeded from each user’s live password hash on their first
 request, which starts a full window for them. Later changes made outside the
 actions — `ckan user setpass`, for instance — are picked up the same way.
 
+### Not enforced here
+
+Nothing in a CKAN extension can enforce these, and they are listed so the gap
+is visible rather than assumed covered:
+
+- passwords transmitted only under TLS (IA-5.1 c) — an ingress concern;
+- admin accounts not sharing a password with the holder’s AD account (f);
+- passphrases not reused outside SSE;
+- “not a single dictionary word” is only as good as the configured blocklist
+  file; the built-in list covers common passwords, not the dictionary.
+
+Related controls in the same standards that this extension does **not**
+implement, and which need their own work: AC-7 (lock an account for 30 minutes
+after six consecutive failed logons), AC-2.3 (disable accounts after 45 days
+without a logon), and AC-2.5/AC-11 (idle session timeout).
+
 ### Settings
 
 | Setting | Default | Effect |
 | --- | --- | --- |
 | `ckanext.sse.password.min_length` | `12` | Minimum length. Floor of 8. |
+| `ckanext.sse.password.privileged_min_length` | `15` | Minimum for sysadmins. |
 | `ckanext.sse.password.max_length` | `128` | Maximum length. Caps the cost of hashing an oversized submission. |
-| `ckanext.sse.password.history_length` | `5` | Previous passwords that may not be reused. `0` checks only the current one. |
-| `ckanext.sse.password.expiry_days` | `90` | Rotation window. `0` disables the block entirely. |
+| `ckanext.sse.password.history_length` | `8` | Previous passwords that may not be reused. `0` checks only the current one. |
+| `ckanext.sse.password.expiry_days` | `365` | Rotation window. `0` disables the block entirely. |
+| `ckanext.sse.password.privileged_expiry_days` | `60` | Rotation window for sysadmins. |
 | `ckanext.sse.password.warn_days` | `14` | How far ahead of expiry to warn, once per browser session. `0` disables. |
+| `ckanext.sse.password.max_repeat` | `4` | Longest run of one repeated character still allowed. |
+| `ckanext.sse.password.max_digit_sequence` | `2` | Longest run of consecutive digits still allowed. |
+| `ckanext.sse.password.max_letter_sequence` | `3` | Longest run of consecutive letters still allowed. |
+| `ckanext.sse.password.increment_window` | `3` | How far either side of the number to look when detecting an incremented password. |
+| `ckanext.sse.password.require_character_classes` | `false` | Demand upper, lower, digit and symbol. Off, because the standard prefers passphrases. |
+| `ckanext.sse.password.blocklist_file` | – | Path to a maintained blocklist, one word per line. |
 | `ckanext.sse.password.extra_blocklist` | – | Extra words banned anywhere in a password, space or comma separated. |
 
 ### Note for tests

--- a/ckanext/sse/account_lifecycle.py
+++ b/ckanext/sse/account_lifecycle.py
@@ -9,10 +9,32 @@ automatically once they are "eligible for disablement", which it defines as:
 
 The second clause is what stops a newly issued account being disabled before
 its holder has had a chance to use it, and the third is the exemption list for
-accounts that are supposed to sit idle. Here that is
-``ckanext.sse.inactivity.exempt_users`` plus, by default, sysadmins -- an
-automated sweep that disables every administrator during a quiet month would
-leave nobody able to undo it.
+accounts that are supposed to sit idle -- here
+``ckanext.sse.inactivity.exempt_users``, plus the site user, which is what
+CKAN's own internal calls authenticate as.
+
+Who the sweep applies to
+------------------------
+
+Only accounts that carry some privilege: sysadmins, members, editors and
+admins of an organisation, and -- because they can edit datasets too -- users
+made collaborators on a dataset.
+
+The control exists to shrink the set of standing privileged access paths. A
+registered account with no organisation and no collaboration has read access
+to public data, which is what the portal offers anonymously anyway, so
+disabling it after 45 days would churn ordinary data consumers without
+retiring any access. This portal's registered population is mostly exactly
+that. Organisation *members* are in scope even though the capacity is
+read-only, because membership carries access to that organisation's private
+datasets, which anonymous visitors do not have.
+
+Set ``ckanext.sse.inactivity.privileged_only`` to false to sweep every dormant
+account regardless.
+
+Sysadmins are in scope. If a sweep ever disables the last active sysadmin,
+``ckan sysadmin add <name>`` from a shell restores one -- the recovery path is
+outside the web session the sweep can affect.
 
 "Last logon" is read from ``user.last_active``, which CKAN stamps on every
 authenticated request rather than only at sign-in. That is the better reading
@@ -35,7 +57,10 @@ Configuration
 ===================================================== ====================
 ``ckanext.sse.inactivity.idle_days``                  45
 ``ckanext.sse.inactivity.min_account_age_days``       30
-``ckanext.sse.inactivity.exempt_sysadmins``           true
+``ckanext.sse.inactivity.privileged_only``            true
+``ckanext.sse.inactivity.capacities``                 admin editor member
+``ckanext.sse.inactivity.include_collaborators``      true
+``ckanext.sse.inactivity.exempt_sysadmins``           false
 ``ckanext.sse.inactivity.exempt_users``               names, space separated
 ===================================================== ====================
 """
@@ -97,9 +122,89 @@ def exempt_users():
 
 
 def exempt_sysadmins():
+    """Whether to leave sysadmins alone.
+
+    False by default: a sysadmin account is the most valuable one on the site,
+    so an idle one is exactly what the control is for. Where it has to be
+    turned on -- an emergency account that is supposed to sit unused -- prefer
+    naming it in ``exempt_users``, which is narrower.
+    """
     return toolkit.asbool(
-        toolkit.config.get("ckanext.sse.inactivity.exempt_sysadmins", True)
+        toolkit.config.get("ckanext.sse.inactivity.exempt_sysadmins", False)
     )
+
+
+def privileged_only():
+    """Whether the sweep is limited to accounts that carry privilege."""
+    return toolkit.asbool(
+        toolkit.config.get("ckanext.sse.inactivity.privileged_only", True)
+    )
+
+
+def include_collaborators():
+    """Whether a dataset collaboration counts as privilege.
+
+    It does by default. A collaborator with the editor capacity can change
+    datasets without belonging to any organisation, so leaving them out would
+    exempt the very access the control is meant to retire.
+    """
+    return toolkit.asbool(
+        toolkit.config.get("ckanext.sse.inactivity.include_collaborators",
+                           True)
+    )
+
+
+def capacities():
+    """Membership capacities that put an account in scope.
+
+    All three by default. ``member`` is read-only within the organisation, but
+    it still carries access to that organisation's private datasets, which is
+    access an anonymous visitor does not have.
+    """
+    configured = toolkit.config.get("ckanext.sse.inactivity.capacities",
+                                    "admin editor member")
+    return {
+        capacity.lower()
+        for capacity in re.split(r"[,\s]+", (configured or "").strip())
+        if capacity
+    }
+
+
+def privileged_user_ids():
+    """Every user id holding an organisation membership or collaboration.
+
+    One query per relationship rather than one per user: the sweep looks at
+    every account on the site, and asking the database about each in turn
+    would be a query per user for no benefit.
+    """
+    wanted = capacities()
+
+    members = (
+        Session.query(core_model.Member.table_id)
+        .join(core_model.Group,
+              core_model.Member.group_id == core_model.Group.id)
+        .filter(
+            core_model.Member.table_name == "user",
+            core_model.Member.state == core_model.State.ACTIVE,
+            core_model.Member.capacity.in_(wanted),
+            # Organisations only. This portal also uses ``user_group`` groups,
+            # membership of which grants read access to datasets shared with
+            # the group and no write access at all.
+            core_model.Group.is_organization.is_(True),
+            core_model.Group.state == core_model.State.ACTIVE,
+        )
+        .all()
+    )
+    ids = {row.table_id for row in members}
+
+    if include_collaborators():
+        collaborators = (
+            Session.query(core_model.PackageMember.user_id)
+            .filter(core_model.PackageMember.capacity.in_(wanted))
+            .all()
+        )
+        ids |= {row.user_id for row in collaborators}
+    return ids
 
 
 def last_activity(user):
@@ -107,7 +212,22 @@ def last_activity(user):
     return user.last_active or user.created
 
 
-def is_eligible(user, now=None, idle=None, min_age=None):
+def is_privileged(user, privileged_ids=None):
+    """Whether this account carries privilege worth retiring.
+
+    ``privileged_ids`` is the precomputed set from ``privileged_user_ids()``;
+    without it the set is built on the spot, which is fine for one account and
+    wasteful for a sweep.
+    """
+    if user.sysadmin:
+        return True
+    if privileged_ids is None:
+        privileged_ids = privileged_user_ids()
+    return user.id in privileged_ids
+
+
+def is_eligible(user, now=None, idle=None, min_age=None,
+                privileged_ids=None):
     """Whether AC-2.3's criteria are all met for this account."""
     now = now or datetime.datetime.utcnow()
     idle = idle if idle is not None else idle_days()
@@ -118,6 +238,8 @@ def is_eligible(user, now=None, idle=None, min_age=None):
     if user.name and user.name.lower() in exempt_users():
         return False
     if user.sysadmin and exempt_sysadmins():
+        return False
+    if privileged_only() and not is_privileged(user, privileged_ids):
         return False
     if not user.created or (now - user.created).days <= min_age:
         return False
@@ -137,9 +259,11 @@ def find_eligible(now=None, idle=None, min_age=None):
         .filter(core_model.User.state == core_model.State.ACTIVE)
         .all()
     )
+    privileged_ids = privileged_user_ids() if privileged_only() else None
     eligible = [
         user for user in users
-        if is_eligible(user, now=now, idle=idle, min_age=min_age)
+        if is_eligible(user, now=now, idle=idle, min_age=min_age,
+                       privileged_ids=privileged_ids)
     ]
     return sorted(eligible, key=lambda user: last_activity(user)
                   or datetime.datetime.min)
@@ -163,6 +287,9 @@ def disable_inactive_users(dry_run=False, now=None, idle=None, min_age=None):
             if user.last_active else None,
             "created": user.created.isoformat() if user.created else None,
             "idle_days": (now - seen).days if seen else None,
+            # Why the account was in scope at all, so the evidence AC-2.3 asks
+            # for shows the access that was retired, not just a name.
+            "sysadmin": bool(user.sysadmin),
         }
         disabled.append(record)
 

--- a/ckanext/sse/account_lifecycle.py
+++ b/ckanext/sse/account_lifecycle.py
@@ -1,0 +1,190 @@
+"""Disablement of dormant accounts (AC-2.3).
+
+SSE's *Standard for Access Control* AC-2.3 requires accounts to be disabled
+automatically once they are "eligible for disablement", which it defines as:
+
+* last logon greater than 45 days ago;
+* creation date greater than 30 days ago;
+* not in any "Admin Disablement" AD group.
+
+The second clause is what stops a newly issued account being disabled before
+its holder has had a chance to use it, and the third is the exemption list for
+accounts that are supposed to sit idle. Here that is
+``ckanext.sse.inactivity.exempt_users`` plus, by default, sysadmins -- an
+automated sweep that disables every administrator during a quiet month would
+leave nobody able to undo it.
+
+"Last logon" is read from ``user.last_active``, which CKAN stamps on every
+authenticated request rather than only at sign-in. That is the better reading
+of the control's intent -- an account making daily API calls is plainly in use
+-- and it is the only per-user timestamp CKAN keeps. Accounts that have never
+been active fall back to their creation date, so an account created 60 days
+ago and never used is eligible, which is the case the control most wants
+caught.
+
+"Disabled" means CKAN's ``deleted`` state: the account can no longer sign in,
+and a sysadmin can restore it from the user edit form. Nothing is destroyed.
+
+There is no scheduler in a CKAN extension, so the sweep is a command --
+``ckan sse disable-inactive-users`` -- to be run from cron or a Kubernetes
+CronJob. It is idempotent and has a ``--dry-run``.
+
+Configuration
+-------------
+
+===================================================== ====================
+``ckanext.sse.inactivity.idle_days``                  45
+``ckanext.sse.inactivity.min_account_age_days``       30
+``ckanext.sse.inactivity.exempt_sysadmins``           true
+``ckanext.sse.inactivity.exempt_users``               names, space separated
+===================================================== ====================
+"""
+
+import datetime
+import logging
+import re
+
+import ckan.model as core_model
+import ckan.plugins.toolkit as toolkit
+from ckan.model.meta import Session
+
+from ckanext.sse.audit import emit_audit_log
+
+log = logging.getLogger(__name__)
+
+# AC-2.3 e: "Last Logon GREATER THAN 45 days".
+DEFAULT_IDLE_DAYS = 45
+
+# AC-2.3 e: "Creation Date GREATER THAN 30 days".
+DEFAULT_MIN_ACCOUNT_AGE_DAYS = 30
+
+
+def _int_config(key, default):
+    raw = toolkit.config.get(key, default)
+    try:
+        return max(0, toolkit.asint(raw))
+    except (ValueError, TypeError):
+        log.warning("Ignoring invalid %s %r, using %s", key, raw, default)
+        return default
+
+
+def idle_days():
+    return _int_config("ckanext.sse.inactivity.idle_days", DEFAULT_IDLE_DAYS)
+
+
+def min_account_age_days():
+    return _int_config("ckanext.sse.inactivity.min_account_age_days",
+                       DEFAULT_MIN_ACCOUNT_AGE_DAYS)
+
+
+def exempt_users():
+    """Accounts the sweep must never touch.
+
+    The site user is in here unconditionally. It is what CKAN's own internal
+    calls authenticate as, it never signs in, and disabling it breaks the
+    site rather than securing it.
+    """
+    configured = toolkit.config.get("ckanext.sse.inactivity.exempt_users", "")
+    names = {
+        name.lower()
+        for name in re.split(r"[,\s]+", (configured or "").strip())
+        if name
+    }
+    site_user = toolkit.config.get("ckan.site_id", "")
+    if site_user:
+        names.add(site_user.lower())
+    return names
+
+
+def exempt_sysadmins():
+    return toolkit.asbool(
+        toolkit.config.get("ckanext.sse.inactivity.exempt_sysadmins", True)
+    )
+
+
+def last_activity(user):
+    """When this account was last used, falling back to its creation."""
+    return user.last_active or user.created
+
+
+def is_eligible(user, now=None, idle=None, min_age=None):
+    """Whether AC-2.3's criteria are all met for this account."""
+    now = now or datetime.datetime.utcnow()
+    idle = idle if idle is not None else idle_days()
+    min_age = min_age if min_age is not None else min_account_age_days()
+
+    if user.state != core_model.State.ACTIVE:
+        return False
+    if user.name and user.name.lower() in exempt_users():
+        return False
+    if user.sysadmin and exempt_sysadmins():
+        return False
+    if not user.created or (now - user.created).days <= min_age:
+        return False
+
+    seen = last_activity(user)
+    if seen is None:
+        # No creation date and no activity: too little to judge on, and the
+        # age clause above should already have excluded it.
+        return False
+    return (now - seen).days > idle
+
+
+def find_eligible(now=None, idle=None, min_age=None):
+    """Every account AC-2.3 says should be disabled, oldest activity first."""
+    users = (
+        Session.query(core_model.User)
+        .filter(core_model.User.state == core_model.State.ACTIVE)
+        .all()
+    )
+    eligible = [
+        user for user in users
+        if is_eligible(user, now=now, idle=idle, min_age=min_age)
+    ]
+    return sorted(eligible, key=lambda user: last_activity(user)
+                  or datetime.datetime.min)
+
+
+def disable_inactive_users(dry_run=False, now=None, idle=None, min_age=None):
+    """Disable every eligible account. Returns what was (or would be) done.
+
+    Idempotent: a disabled account is no longer active, so a second run finds
+    nothing left to do.
+    """
+    now = now or datetime.datetime.utcnow()
+    disabled = []
+
+    for user in find_eligible(now=now, idle=idle, min_age=min_age):
+        seen = last_activity(user)
+        record = {
+            "id": user.id,
+            "name": user.name,
+            "last_active": user.last_active.isoformat()
+            if user.last_active else None,
+            "created": user.created.isoformat() if user.created else None,
+            "idle_days": (now - seen).days if seen else None,
+        }
+        disabled.append(record)
+
+        if dry_run:
+            continue
+
+        user.state = core_model.State.DELETED
+        Session.add(user)
+        # Committed per user rather than in one transaction at the end: a
+        # sweep that fails half way should keep the accounts it has already
+        # dealt with, and the audit line for each should be true when written.
+        Session.commit()
+        emit_audit_log(
+            action="user_disabled",
+            status="success",
+            user_name=user.name,
+            user_id=user.id,
+            message="Account {} disabled after {} days without activity"
+                    .format(user.name, record["idle_days"]),
+            reason="inactivity",
+            idle_days=record["idle_days"],
+            last_active=record["last_active"],
+        )
+
+    return disabled

--- a/ckanext/sse/action.py
+++ b/ckanext/sse/action.py
@@ -11,8 +11,7 @@ from ckanext.scheming.helpers import (
     scheming_field_by_name,
 )
 from sqlalchemy import func
-import string
-import random
+from ckanext.sse.password_policy import generate_password
 from .model import PackageAccessRequest, FormResponse
 from .schemas import package_request_access_schema, data_reuse_schema
 import os
@@ -461,11 +460,11 @@ def user_login(context, data_dict):
         )
 
         if not user:
-            password_length = 10
-            password = "".join(
-                random.choice(string.ascii_letters + string.digits)
-                for _ in range(password_length)
-            )
+            # A placeholder nobody is ever told: this account authenticates
+            # through the frontend's shared secret and the API token issued
+            # below, never through this password. It still has to satisfy the
+            # password policy, or ``user_create`` would reject it.
+            password = generate_password()
 
             user_name = "".join(
                 c.lower() if c.isalnum() else "_" for c in email.split("@")[0]

--- a/ckanext/sse/cli.py
+++ b/ckanext/sse/cli.py
@@ -1,0 +1,85 @@
+"""``ckan sse ...`` commands.
+
+Two of the access-control standards need something to run outside a request:
+AC-2.3 wants dormant accounts disabled automatically, which means a scheduled
+sweep, and AC-7 wants a locked account to be releasable "by an administrator",
+which means a way to release it.
+"""
+
+import click
+
+from ckanext.sse import account_lifecycle, login_throttle
+
+
+@click.group(short_help="SSE portal administration")
+def sse():
+    pass
+
+
+@sse.command()
+@click.option("--dry-run", is_flag=True,
+              help="List the accounts without disabling them.")
+@click.option("--idle-days", type=int, default=None,
+              help="Override ckanext.sse.inactivity.idle_days.")
+@click.option("--min-age-days", type=int, default=None,
+              help="Override ckanext.sse.inactivity.min_account_age_days.")
+def disable_inactive_users(dry_run, idle_days, min_age_days):
+    """Disable accounts dormant beyond the AC-2.3 threshold.
+
+    Intended for cron or a Kubernetes CronJob. Idempotent, so a missed run
+    costs nothing and a repeated one does nothing.
+    """
+    disabled = account_lifecycle.disable_inactive_users(
+        dry_run=dry_run, idle=idle_days, min_age=min_age_days,
+    )
+
+    for record in disabled:
+        click.echo("{}\t{} days idle\tlast active {}".format(
+            record["name"], record["idle_days"],
+            record["last_active"] or "never",
+        ))
+
+    verb = "would be disabled" if dry_run else "disabled"
+    click.secho("{} account(s) {}".format(len(disabled), verb),
+                fg="yellow" if disabled else "green")
+
+
+@sse.command()
+@click.argument("login")
+def login_status(login):
+    """Show the failed-login count and lock state for LOGIN."""
+    key = login_throttle.throttle_key(login)
+    if key is None:
+        raise click.ClickException("Not a usable login name")
+
+    state = login_throttle.status(key)
+    click.echo("account:  {}".format(state["key"]))
+    click.echo("failures: {} of {}".format(state["failures"],
+                                           login_throttle.max_attempts()))
+    if state["locked"]:
+        click.secho("locked:   yes, for another {} second(s)".format(
+            state["seconds_remaining"]), fg="red")
+    else:
+        click.secho("locked:   no", fg="green")
+
+
+@sse.command()
+@click.argument("login")
+def unlock_login(login):
+    """Release the AC-7 lockout on LOGIN.
+
+    The lock expires on its own after the configured window; this is the
+    "or until released by an administrator" half of the control.
+    """
+    key = login_throttle.throttle_key(login)
+    if key is None:
+        raise click.ClickException("Not a usable login name")
+
+    if login_throttle.clear(key):
+        click.secho("Unlocked {}".format(key), fg="green")
+    else:
+        click.echo("{} was not locked; failure count cleared".format(key))
+
+
+def get_commands():
+    return [sse]

--- a/ckanext/sse/login_throttle.py
+++ b/ckanext/sse/login_throttle.py
@@ -1,0 +1,373 @@
+"""Account lockout after repeated failed logins (AC-7).
+
+SSE's *Standard for Access Control* AC-7 requires a limit of six consecutive
+invalid logon attempts by a user, and that the account is then locked "for 30
+minutes or until released by an administrator". CKAN has no lockout of any
+kind: an unlimited number of guesses can be made against any account.
+
+The mechanism follows ``ckanext-security``: two Redis keys per account, a
+counter and a lock, both carrying their own expiry so nothing has to be swept
+up afterwards. Redis rather than a table because the state is short-lived by
+definition, an expiring key *is* the 30-minute timer, and ``INCR`` is atomic
+across workers where a read-modify-write against Postgres would not be.
+
+Where this departs from ``ckanext-security`` is the hook, and for a concrete
+reason. That extension counts attempts from ``IAuthenticator.authenticate()``,
+which calls ``default_authenticate()`` itself and returns ``None`` when the
+credentials are wrong. ``ckan_authenticator`` (``ckan/lib/authenticator.py``)
+reads ``None`` as "this plugin has no opinion" and falls through to
+``default_authenticate()`` a second time, so every failed login is
+authenticated twice and emits the ``failed_login`` signal twice -- which this
+deployment records in its audit trail. Counting from the signal instead, and
+blocking from a ``before_app_request`` handler that runs before the login view,
+keeps one attempt to one event.
+
+Two consequences of counting from the signal are worth knowing:
+
+* ``failed_login`` also fires for the old-password check on the profile form
+  (``EditView`` authenticates before it will change a password), so receivers
+  are filtered to the login endpoint. Mistyping your current password while
+  changing it is not a logon attempt and must not lock the account.
+* The lock is checked before the view runs, so it applies whether or not the
+  credentials presented during the lock are correct.
+
+Keyed on the account, which is what the standard asks for and what makes the
+limit meaningful -- an attacker changing address every attempt would defeat a
+per-address counter. The cost is that a third party can lock a known account
+out by failing six times against it. That is inherent in an account-lockout
+control, and the 30-minute expiry bounds it.
+
+An attempt against a login that matches no account is counted under whatever
+was typed, so spraying does not get an unlimited budget against nonexistent
+names either.
+
+Redis being unavailable fails *open*: the attempt is allowed and an error is
+logged. The alternative is an outage in a cache locking every user out of the
+portal.
+
+Configuration
+-------------
+
+=============================================== ==========================
+``ckanext.sse.login.max_attempts``              6
+``ckanext.sse.login.lockout_minutes``           30
+``ckanext.sse.login.attempt_window_minutes``    30
+``ckanext.sse.login.notify_lockout``            true
+=============================================== ==========================
+"""
+
+import logging
+
+from flask import Blueprint, has_request_context
+from flask_login import user_logged_in
+
+import ckan.lib.mailer as mailer
+import ckan.model as core_model
+import ckan.plugins.toolkit as toolkit
+from ckan.lib.redis import connect_to_redis
+
+from ckanext.sse.audit import emit_audit_log
+
+log = logging.getLogger(__name__)
+
+_ = toolkit._
+
+# AC-7 a: "Enforce a limit of six consecutive invalid logon attempts by a
+# user".
+DEFAULT_MAX_ATTEMPTS = 6
+
+# AC-7 b: "Automatically lock the account for 30 minutes or until released by
+# an administrator".
+DEFAULT_LOCKOUT_MINUTES = 30
+
+# How long a failure is remembered. The standard says "consecutive" without
+# bounding the gap; an attempt an hour after the last one is not really part
+# of the same run, and without an expiry a counter left at five would lock an
+# account on a single typo months later.
+DEFAULT_ATTEMPT_WINDOW_MINUTES = 30
+
+# The endpoint whose failures count. Deliberately not every call to CKAN's
+# authenticator -- see the module docstring.
+LOGIN_ENDPOINT = "user.login"
+
+FAILURE_KEY = "sse:login:failures:{}"
+LOCK_KEY = "sse:login:lock:{}"
+
+
+def get_subscriptions():
+    return {
+        toolkit.signals.failed_login: [on_failed_login],
+        user_logged_in: [on_user_logged_in],
+    }
+
+
+# --------------------------------------------------------------------------
+# Configuration
+# --------------------------------------------------------------------------
+
+
+def _int_config(key, default, minimum=1):
+    raw = toolkit.config.get(key, default)
+    try:
+        value = toolkit.asint(raw)
+    except (ValueError, TypeError):
+        log.warning("Ignoring invalid %s %r, using %s", key, raw, default)
+        return default
+    return max(minimum, value)
+
+
+def max_attempts():
+    return _int_config("ckanext.sse.login.max_attempts",
+                       DEFAULT_MAX_ATTEMPTS)
+
+
+def lockout_seconds():
+    return _int_config("ckanext.sse.login.lockout_minutes",
+                       DEFAULT_LOCKOUT_MINUTES) * 60
+
+
+def attempt_window_seconds():
+    return _int_config("ckanext.sse.login.attempt_window_minutes",
+                       DEFAULT_ATTEMPT_WINDOW_MINUTES) * 60
+
+
+def notify_on_lockout():
+    return toolkit.asbool(
+        toolkit.config.get("ckanext.sse.login.notify_lockout", True)
+    )
+
+
+# --------------------------------------------------------------------------
+# State
+# --------------------------------------------------------------------------
+
+
+def throttle_key(login):
+    """The account an attempt counts against.
+
+    Resolved through the user table so that ``jbloggs`` and
+    ``joe@example.com`` share one budget rather than two -- CKAN accepts
+    either at the login form. An attempt against a login matching no account
+    is counted under what was typed, lower-cased so case cannot multiply the
+    budget either.
+    """
+    if not login or not isinstance(login, str):
+        return None
+    login = login.strip()
+    if not login:
+        return None
+
+    user = core_model.User.by_name(login) or core_model.User.by_email(login)
+    if user is not None:
+        return user.name
+    return login.lower()
+
+
+def _redis():
+    return connect_to_redis()
+
+
+def is_locked(key):
+    """Whether this account is inside its lockout window."""
+    if not key:
+        return False
+    try:
+        return bool(_redis().exists(LOCK_KEY.format(key)))
+    except Exception:
+        # Failing open: see the module docstring.
+        log.exception("Login lockout check failed; allowing the attempt")
+        return False
+
+
+def lock_seconds_remaining(key):
+    """Seconds left on the lock, or 0. For the message shown to the user."""
+    try:
+        return max(0, int(_redis().ttl(LOCK_KEY.format(key)) or 0))
+    except Exception:
+        return 0
+
+
+def record_failure(key, user=None):
+    """Count one failed attempt, locking the account once the limit is hit.
+
+    Returns the running count, or ``None`` if the count could not be kept.
+    """
+    if not key:
+        return None
+    try:
+        redis = _redis()
+        failures = FAILURE_KEY.format(key)
+        count = redis.incr(failures)
+        if count == 1:
+            # Only the first failure sets the expiry, so a run of attempts is
+            # measured from its start rather than being extended indefinitely
+            # by the attacker's own traffic.
+            redis.expire(failures, attempt_window_seconds())
+        if count >= max_attempts():
+            _lock(key, user)
+            redis.delete(failures)
+        return count
+    except Exception:
+        log.exception("Could not record a failed login for %s", key)
+        return None
+
+
+def _lock(key, user):
+    seconds = lockout_seconds()
+    _redis().set(LOCK_KEY.format(key), "1", ex=seconds)
+
+    emit_audit_log(
+        action="user_lockout",
+        status="failure",
+        user_name=getattr(user, "name", None) or key,
+        user_id=getattr(user, "id", None),
+        message="Account {} locked for {} seconds after {} failed login "
+                "attempts".format(key, seconds, max_attempts()),
+        lockout_seconds=seconds,
+        failed_attempts=max_attempts(),
+        # An attempt against a name that matches no account is still worth
+        # recording, and worth being able to tell apart from a real one.
+        account_exists=user is not None,
+    )
+
+    if user is not None and notify_on_lockout():
+        _notify(user, seconds)
+
+
+def _notify(user, seconds):
+    """Tell the account holder their account has been locked.
+
+    They are the one person who can tell an attack from their own typo, and
+    the lock is otherwise invisible until they next try to sign in. Failure to
+    send must not prevent the lock.
+    """
+    try:
+        mailer.mail_recipient(
+            user.display_name or user.name,
+            user.email,
+            _("Your {site} account has been locked").format(
+                site=toolkit.config.get("ckan.site_title", "CKAN")),
+            _("Your account was locked for {minutes} minutes after {n} "
+              "failed sign-in attempts.\n\n"
+              "If this was you, you can sign in again once that time has "
+              "passed, or reset your password.\n\n"
+              "If it was not you, someone is trying to guess your password. "
+              "Please contact the site administrators.").format(
+                  minutes=seconds // 60, n=max_attempts()),
+        )
+    except Exception:
+        log.exception("Could not send a lockout notification to %s", user.name)
+
+
+def clear(key):
+    """Release a lock and forget the failures. Used by the CLI."""
+    try:
+        redis = _redis()
+        removed = redis.delete(LOCK_KEY.format(key))
+        redis.delete(FAILURE_KEY.format(key))
+        return bool(removed)
+    except Exception:
+        log.exception("Could not clear the login lock for %s", key)
+        return False
+
+
+def status(key):
+    """Failure count and remaining lock time, for the CLI."""
+    try:
+        redis = _redis()
+        raw = redis.get(FAILURE_KEY.format(key))
+        return {
+            "key": key,
+            "failures": int(raw) if raw else 0,
+            "locked": bool(redis.exists(LOCK_KEY.format(key))),
+            "seconds_remaining": lock_seconds_remaining(key),
+        }
+    except Exception:
+        log.exception("Could not read the login state for %s", key)
+        return {"key": key, "failures": 0, "locked": False,
+                "seconds_remaining": 0}
+
+
+# --------------------------------------------------------------------------
+# Hooks
+# --------------------------------------------------------------------------
+
+
+def _is_login_attempt():
+    """Whether this request is a submission of the login form."""
+    return (
+        has_request_context()
+        and toolkit.request.endpoint == LOGIN_ENDPOINT
+        and toolkit.request.method == "POST"
+    )
+
+
+def on_failed_login(sender, **kwargs):
+    """CKAN's ``failed_login``: the attempted login name is the sender."""
+    try:
+        if not _is_login_attempt():
+            return
+        login = sender if isinstance(sender, str) else None
+        key = throttle_key(login)
+        if key is None:
+            return
+        user = core_model.User.by_name(key)
+        record_failure(key, user)
+    except Exception:
+        log.exception("Failed to record a login failure")
+
+
+def on_user_logged_in(sender, user=None, **kwargs):
+    """A successful login ends the run, which is what "consecutive" means."""
+    try:
+        name = getattr(user, "name", None)
+        if name:
+            clear(name)
+    except Exception:
+        log.exception("Failed to reset the login failure count")
+
+
+def check_login_lock():
+    """Refuse a login submission while the account is locked.
+
+    Runs before the login view, so the credentials presented are never
+    checked and a correct password does not shorten the lockout.
+
+    Nothing here may raise: it runs before every request.
+    """
+    try:
+        if not _is_login_attempt():
+            return None
+
+        key = throttle_key(toolkit.request.form.get("login"))
+        if key is None or not is_locked(key):
+            return None
+
+        minutes = max(1, lock_seconds_remaining(key) // 60)
+        toolkit.h.flash_error(
+            _("Too many failed sign-in attempts. This account is locked for "
+              "another {minutes} minute(s). Contact the site administrators "
+              "if you need access sooner.").format(minutes=minutes)
+        )
+        emit_audit_log(
+            action="user_login",
+            status="failure",
+            user_name=key,
+            message="Login attempt for locked account {}".format(key),
+            locked_out=True,
+        )
+        return toolkit.redirect_to(LOGIN_ENDPOINT)
+    except Exception:
+        log.exception("Login lock check failed; allowing the request")
+        return None
+
+
+# Routeless: it exists only to hang the lock check off ``before_app_request``.
+# See ``ckanext.sse.password_policy`` for why an IAuthenticator hook is not
+# used for this kind of check.
+blueprint = Blueprint("sse_login_throttle", __name__)
+
+
+@blueprint.before_app_request
+def _before_app_request():
+    return check_login_lock()

--- a/ckanext/sse/model.py
+++ b/ckanext/sse/model.py
@@ -1,7 +1,9 @@
 from datetime import datetime, date
 from collections import OrderedDict
 
-from sqlalchemy import orm, Column, String, Text, DateTime, ForeignKey, Enum
+from sqlalchemy import (
+    orm, Column, String, Text, DateTime, ForeignKey, Enum, Index,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.types import Unicode
 from sqlalchemy.orm import relationship
@@ -148,6 +150,52 @@ class PackageAccessRequest(Base):
             Session.commit()
             return request
         return None
+
+
+class UserPasswordHistory(tk.BaseModel):
+    """One row per password a user has held, newest last.
+
+    Serves both halves of the password policy: the newest row's
+    ``created_at`` is when the password was last changed, which is what the
+    rotation window is measured from, and the stored hashes are what a
+    proposed new password is checked against for reuse.
+
+    The hash is copied from ``user.password`` rather than re-derived, so a row
+    is only ever as strong as CKAN's own storage -- pbkdf2-sha512 at the
+    rounds in force when it was set. Rows beyond the configured history length
+    are deleted rather than kept, so no more old credential material is
+    retained than the policy actually needs.
+
+    There is no unique constraint on ``(user_id, password_hash)``: pbkdf2
+    salts every hash, so the same password set twice produces two different
+    hashes and the database cannot recognise the repeat. Reuse is caught by
+    verifying the candidate against each stored hash instead -- see
+    ``ckanext.sse.password_policy.is_reused``.
+    """
+
+    __tablename__ = "user_password_history"
+    __table_args__ = (
+        # Every lookup is "the newest rows for this user", so the ordering
+        # column belongs in the index. Without it this is a sort per
+        # authenticated page request.
+        Index(
+            "idx_user_password_history_user_created",
+            "user_id",
+            "created_at",
+        ),
+    )
+
+    id = Column(Unicode(64), primary_key=True, default=make_uuid)
+    user_id = Column(String(60), ForeignKey("user.id"), nullable=False)
+    # Not String(n): the hash length is passlib's to decide, and it has grown
+    # before now.
+    password_hash = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    user = relationship(User, foreign_keys=[user_id])
+
+    def __repr__(self):
+        return f"<UserPasswordHistory {self.user_id} {self.created_at}>"
 
 
 class FormResponse(DomainObject.DomainObject, tk.BaseModel):

--- a/ckanext/sse/password_policy.py
+++ b/ckanext/sse/password_policy.py
@@ -1,0 +1,890 @@
+"""Password strength, reuse and rotation policy.
+
+Three separate controls, all driven from this module:
+
+* **Strength** -- CKAN's own rule is "8 characters or longer" and nothing
+  else. ``user_password_validator`` here replaces it. The replacement is
+  picked up by *name*: ``ckan.logic.schema`` resolves its validators through
+  ``logic.get_validator``, which lets ``IValidators`` implementations shadow
+  core ones, so a single entry in ``get_validators()`` covers ``user_create``,
+  ``user_update``, the registration form, the profile form and the
+  forgotten-password reset in one go. Overriding the schemas instead would
+  have meant chasing five of them.
+
+  ``ckan/views/user.py`` keeps its own hardcoded 8-character check in
+  ``PerformResetView._get_form_password``, which runs *before* the action.
+  That is a floor, not a ceiling: the action still validates, so a weak
+  password submitted to the reset form is still rejected -- just with the
+  error rendered from ``error_dict`` rather than beside the field.
+
+* **Reuse** -- every password a user has held is recorded in
+  ``user_password_history`` and a candidate is verified against each of the
+  retained hashes. pbkdf2 salts per hash, so a repeated password cannot be
+  recognised by comparing hashes; it has to be verified one at a time, which
+  is why the history length is bounded.
+
+* **Rotation** -- once a password is older than the configured window the user
+  is redirected to the profile form until they change it. Enforced from a
+  ``before_app_request`` handler on the routeless blueprint at the bottom of
+  this module, which Flask runs before dispatching any view and which
+  short-circuits the request if it returns a response.
+
+  ``IAuthenticator.identify`` looks like the natural hook and is not one.
+  ``identify_user()`` stops calling authenticators as soon as one of them
+  leaves a user identified (``ckan/views/__init__.py``), and
+  ``ckanext-noanonaccess`` is ahead of this extension in ``ckan.plugins``, so
+  for an authenticated user -- the only kind this check applies to --
+  ``identify()`` here is never reached. Measured, not assumed: the redirect
+  silently did nothing until this moved to a blueprint handler. CKAN registers
+  its own ``before_request`` before any extension blueprint, so by the time
+  this runs ``current_user`` is resolved.
+
+Enforcement is deliberately limited to browser requests. The action API is
+exempt: an API token is a separate credential with its own lifecycle, its
+holder may be an integration whose owner never signs in to a page, and
+answering a JSON call with a redirect to an HTML form breaks the client
+rather than protecting anything.
+
+When the password was last changed
+----------------------------------
+
+There is no such column on ``user``, and several code paths change a password
+without going through an action at all -- ``ckan user setpass`` assigns
+``user.password`` and commits. So the history table is *reconciled* against
+the live hash whenever it is read: a live hash that is not the newest recorded
+one is recorded, with the clock restarted.
+
+That reconciliation is also what seeds the table. Nothing needs migrating and
+no one is locked out on the day this ships: the first request each existing
+user makes records their current hash and starts a full window for them.
+
+The one case reconciliation could misread is CKAN's rehash-on-login. When a
+stored hash predates the current passlib parameters, ``validate_password``
+transparently re-hashes the *same* password at the new rounds and saves it, so
+the hash changes without the password changing. Restarting the rotation clock
+there would silently extend the window, so it is detected -- an old hash below
+current pbkdf2 parameters replaced by one at them -- and the stored hash is
+updated in place, keeping the original date. See ``_looks_like_rehash``.
+
+Configuration (all optional)
+----------------------------
+
+============================================== ==========================
+``ckanext.sse.password.min_length``            12
+``ckanext.sse.password.max_length``            128
+``ckanext.sse.password.history_length``        5 (0 disables the reuse check)
+``ckanext.sse.password.expiry_days``           90 (0 disables rotation)
+``ckanext.sse.password.warn_days``             14 (0 disables the warning)
+``ckanext.sse.password.extra_blocklist``       extra banned words
+============================================== ==========================
+"""
+
+import datetime
+import logging
+import re
+import secrets
+import string
+
+from flask import Blueprint, g, has_request_context
+from passlib.hash import pbkdf2_sha512
+
+import ckan.model as core_model
+import ckan.plugins.toolkit as toolkit
+from ckan.common import session
+from ckan.lib.navl.dictization_functions import Missing
+from ckan.model.meta import Session
+
+from ckanext.sse.model import UserPasswordHistory
+
+log = logging.getLogger(__name__)
+
+_ = toolkit._
+
+DEFAULT_MIN_LENGTH = 12
+
+# Not tidiness: the candidate is fed to pbkdf2 once per history entry plus
+# once to store it, and pbkdf2 cost is linear in input length. Without a cap a
+# multi-megabyte "password" is a cheap way to tie up a worker.
+DEFAULT_MAX_LENGTH = 128
+
+DEFAULT_HISTORY_LENGTH = 5
+DEFAULT_EXPIRY_DAYS = 90
+DEFAULT_WARN_DAYS = 14
+
+# A run of this many identical characters is rejected, so "aaa" is out.
+MAX_REPEAT = 3
+
+# A run of this many consecutive codepoints is rejected, so "1234", "abcd" and
+# "9876" are out.
+MAX_SEQUENCE = 4
+
+# Symbols used when generating a password. Quotes, backslashes and spaces are
+# left out: generated passwords get passed through shells, JSON bodies and
+# .ini files, and a quoting bug there is a lockout.
+GENERATED_SYMBOLS = "!@#$%^&*()-_=+[]{};:,.?"
+
+# Words that must not appear *anywhere* in the password, matched against the
+# letters of the password with common character substitutions undone -- so
+# "P@ssw0rd!2026" is caught by "password". Kept short and unambiguous on
+# purpose: substring matching over a large word list rejects perfectly good
+# passphrases, which pushes users towards the shortest thing that passes.
+#
+# The portal's own names are listed here rather than derived from
+# ``ckan.site_title``, because a title is a sentence: "SSEN Distribution Data
+# Portal" would ban "data" as a substring and take "metadata" and "database"
+# with it. Add site-specific words through
+# ``ckanext.sse.password.extra_blocklist``.
+BANNED_SUBSTRINGS = """
+password passwd letmein changeme
+qwerty qwertz azerty asdfgh zxcvbn abcdef qazwsx
+iloveyou trustno welcome secret
+admin sysadmin guest ckan datopian ssen
+"""
+
+# Common passwords, matched against the password once reduced to its letters,
+# and only when the word accounts for nearly all of them -- so "Monkey2026!"
+# and "Monkey99x" are rejected but "MonkeySawTheSunset" is not. Matching these
+# as substrings instead would ban ordinary English words from passphrases,
+# which is where a passphrase's strength comes from.
+BANNED_WHOLE = """
+monkey dragon football baseball basketball soccer cricket rugby
+superman batman starwars pokemon princess sunshine shadow master
+ninja hunter freedom whatever computer internet samsung google apple
+michael jennifer jordan thomas charlie robert daniel matthew ashley
+buster harley hockey ranger george andrew tigger joshua cheese amanda
+ginger hammer silver purple orange banana chicken flower matrix cookie
+killer jessica pepper maggie mickey bailey hannah nicole lovely sophie
+chocolate friends family please summer winter spring autumn
+liverpool chelsea arsenal celtic rangers glasgow edinburgh aberdeen
+dundee london england scotland scottish southern
+energy portal dataset dataportal opendata electricity distribution
+"""
+
+# How many letters a password may have beyond a ``BANNED_WHOLE`` word before
+# it stops counting as that password. Two, so "monkey" catches "monkeyx" and
+# "xmonkeyy" -- the usual way of getting a rejected password past a checker --
+# without catching a passphrase that happens to contain the word.
+WHOLE_WORD_SLACK = 2
+
+# Substitutions to undo before matching against the word lists. Only the
+# unambiguous ones: mapping "6" to "g" or "2" to "z" mangles more passwords
+# than it catches.
+LEET_MAP = str.maketrans(
+    {
+        "0": "o", "1": "i", "3": "e", "4": "a", "5": "s", "7": "t", "8": "b",
+        "@": "a", "$": "s", "!": "i", "|": "i", "+": "t", "(": "c",
+    }
+)
+
+# Endpoints reachable while a password is expired. Everything else redirects
+# to the profile form.
+#
+# The reset endpoints are here because a user who has forgotten the password
+# they are being asked to replace has no other way through -- the profile form
+# demands the old one. Logout is here so the block is not a trap. Static and
+# asset endpoints are here so the page the user is sent to can render.
+ALLOWED_WHILE_EXPIRED = frozenset(
+    {
+        "user.edit",
+        "user.logout",
+        "user.logged_out",
+        "user.logged_out_page",
+        "user.request_reset",
+        "user.perform_reset",
+        "static",
+        "webassets.index",
+        "_debug_toolbar.static",
+        "util.internal_redirect",
+        "util.redirect",
+    }
+)
+
+# Where an expired user is sent.
+CHANGE_PASSWORD_ENDPOINT = "user.edit"
+
+# Request attribute holding this request's reconciled history row, so a page
+# that consults the policy more than once still costs one query.
+_LATEST_ATTR = "sse_password_latest"
+
+# Session key recording which expiry the user has already been warned about,
+# so the warning appears once per browser session rather than on every page.
+_WARNED_SESSION_KEY = "sse_password_expiry_warned"
+
+
+# --------------------------------------------------------------------------
+# Configuration
+# --------------------------------------------------------------------------
+
+
+def _int_config(key, default, minimum=0):
+    """An int setting, normalised so a bad value cannot break a login."""
+    raw = toolkit.config.get(key, default)
+    try:
+        value = toolkit.asint(raw)
+    except (ValueError, TypeError):
+        log.warning("Ignoring invalid %s %r, using %s", key, raw, default)
+        return default
+    return max(minimum, value)
+
+
+def min_length():
+    return _int_config("ckanext.sse.password.min_length",
+                       DEFAULT_MIN_LENGTH, minimum=8)
+
+
+def max_length():
+    return max(
+        min_length(),
+        _int_config("ckanext.sse.password.max_length", DEFAULT_MAX_LENGTH,
+                    minimum=8),
+    )
+
+
+def history_length():
+    """How many previous passwords may not be reused. 0 disables the check."""
+    return _int_config("ckanext.sse.password.history_length",
+                       DEFAULT_HISTORY_LENGTH)
+
+
+def expiry_days():
+    """Rotation window in days. 0 disables rotation entirely."""
+    return _int_config("ckanext.sse.password.expiry_days",
+                       DEFAULT_EXPIRY_DAYS)
+
+
+def warn_days():
+    """How far ahead of expiry to warn. 0 disables the warning."""
+    return _int_config("ckanext.sse.password.warn_days", DEFAULT_WARN_DAYS)
+
+
+def _word_list(configured, builtin):
+    words = re.split(r"[,\s]+", "{} {}".format(builtin, configured or "").strip())
+    return {word.lower() for word in words if len(word) > 3}
+
+
+def _banned_substrings():
+    """Words banned anywhere in the password."""
+    extra = toolkit.config.get("ckanext.sse.password.extra_blocklist", "")
+    return _word_list(extra, BANNED_SUBSTRINGS)
+
+
+def _banned_whole():
+    return _word_list("", BANNED_WHOLE)
+
+
+# --------------------------------------------------------------------------
+# Strength
+# --------------------------------------------------------------------------
+
+
+def policy_rules():
+    """The policy in words, for error messages and for the forms.
+
+    Generated from the live configuration rather than written out twice: a
+    hint that disagrees with the validator is worse than no hint.
+    """
+    rules = [
+        _("be between {min} and {max} characters long").format(
+            min=min_length(), max=max_length()
+        ),
+        _("contain an uppercase letter, a lowercase letter, a digit and a "
+          "symbol"),
+        _("not repeat the same character {n} or more times in a row").format(
+            n=MAX_REPEAT
+        ),
+        _("not contain {n} or more sequential characters, such as 1234 or "
+          "abcd").format(n=MAX_SEQUENCE),
+        _("not be based on a common password, your username, your full name "
+          "or your email address"),
+    ]
+    if history_length():
+        rules.append(
+            _("not be one of your {n} previous passwords").format(
+                n=history_length()
+            )
+        )
+    if expiry_days():
+        rules.append(
+            _("be changed at least every {n} days").format(n=expiry_days())
+        )
+    return rules
+
+
+def _normalise(password, undo_substitutions):
+    """The password reduced to letters, optionally with leetspeak undone."""
+    text = password.lower()
+    if undo_substitutions:
+        text = text.translate(LEET_MAP)
+    return "".join(char for char in text if char.isalpha())
+
+
+def _has_repeat(password):
+    return re.search(r"(.)\1{%d,}" % (MAX_REPEAT - 1), password) is not None
+
+
+def _has_sequence(password):
+    """Whether the password contains a run of consecutive codepoints.
+
+    Catches ``1234`` and ``abcd`` in either direction. Codepoint arithmetic
+    rather than a keyboard map: ``qwerty`` and friends are handled by the word
+    list, and the point here is the numeric and alphabetic runs people reach
+    for to satisfy a character-class rule.
+    """
+    run = 1
+    step = 0
+    for previous, current in zip(password, password[1:]):
+        delta = ord(current) - ord(previous)
+        if delta in (1, -1) and (step == 0 or delta == step):
+            step = delta
+            run += 1
+            if run >= MAX_SEQUENCE:
+                return True
+        else:
+            step = delta if delta in (1, -1) else 0
+            run = 2 if step else 1
+    return False
+
+
+def _identifier_words(*values):
+    """Words from a user's identity worth banning from their password.
+
+    The email is split on its punctuation as well, so ``joe.bloggs@sse.com``
+    contributes ``joe``, ``bloggs`` and ``sse`` -- the local part as a whole is
+    rarely what someone types.
+    """
+    words = set()
+    for value in values:
+        if not value or not isinstance(value, str):
+            continue
+        for word in re.split(r"[^A-Za-z0-9]+", value.lower()):
+            if len(word) > 3:
+                words.add(word)
+    return words
+
+
+def check_strength(password, identifiers=()):
+    """Every way ``password`` fails the policy, as a list of phrases.
+
+    Phrases, not sentences: the caller joins them into one message because
+    CKAN's ``error_summary`` only ever renders the first error per field, so
+    reporting the failures separately would hide all but one of them.
+    """
+    if not isinstance(password, str):
+        return [_("be a string")]
+
+    failures = []
+    if len(password) < min_length():
+        failures.append(
+            _("be at least {n} characters long").format(n=min_length())
+        )
+    if len(password) > max_length():
+        failures.append(
+            _("be no more than {n} characters long").format(n=max_length())
+        )
+
+    missing = []
+    if not any(char.islower() for char in password):
+        missing.append(_("a lowercase letter"))
+    if not any(char.isupper() for char in password):
+        missing.append(_("an uppercase letter"))
+    if not any(char.isdigit() for char in password):
+        missing.append(_("a digit"))
+    # Anything that is not a letter or a digit counts, including a space, so
+    # passphrases are not pushed towards punctuation soup.
+    if not any(not char.isalnum() for char in password):
+        missing.append(_("a symbol"))
+    if missing:
+        failures.append(_("contain {}").format(", ".join(missing)))
+
+    if _has_repeat(password):
+        failures.append(
+            _("not repeat the same character {n} or more times in a "
+              "row").format(n=MAX_REPEAT)
+        )
+    if _has_sequence(password):
+        failures.append(
+            _("not contain {n} or more sequential characters").format(
+                n=MAX_SEQUENCE
+            )
+        )
+
+    # Both forms are checked: the plain one catches "Password123", the
+    # substituted one catches "P@ssw0rd". Checking only the substituted form
+    # would miss words whose letters the substitutions rewrite.
+    forms = {_normalise(password, False), _normalise(password, True)}
+    if any(word in form
+           for form in forms
+           for word in _banned_substrings()):
+        failures.append(_("not be based on a common or obvious password"))
+    elif any(word in form and len(form) - len(word) <= WHOLE_WORD_SLACK
+             for form in forms
+             for word in _banned_whole()):
+        failures.append(_("not be a commonly used password"))
+
+    lowered = password.lower()
+    if any(word in lowered for word in _identifier_words(*identifiers)):
+        failures.append(
+            _("not contain your username, name or email address")
+        )
+
+    return failures
+
+
+def generate_password(length=None):
+    """A random password that satisfies this policy.
+
+    ``secrets`` rather than ``random``: this produces a real credential, and
+    ``random`` is a Mersenne Twister whose output is recoverable from a
+    handful of samples.
+
+    Candidates are rejected by ``check_strength`` rather than assembled to
+    satisfy each rule, so the generator cannot drift away from the policy --
+    if a rule is added, this keeps producing valid passwords without being
+    touched.
+    """
+    length = max(length or min_length() + 8, min_length())
+    length = min(length, max_length())
+    alphabet = string.ascii_letters + string.digits + GENERATED_SYMBOLS
+    while True:
+        candidate = "".join(secrets.choice(alphabet) for _unused in range(length))
+        if not check_strength(candidate):
+            return candidate
+
+
+# --------------------------------------------------------------------------
+# History
+# --------------------------------------------------------------------------
+
+
+def _history(user_id, limit=None):
+    """Recorded hashes for a user, newest first."""
+    query = (
+        Session.query(UserPasswordHistory)
+        .filter(UserPasswordHistory.user_id == user_id)
+        # id as a tiebreaker: two rows written in the same transaction share a
+        # timestamp, and an unstable order would make pruning arbitrary.
+        .order_by(
+            UserPasswordHistory.created_at.desc(),
+            UserPasswordHistory.id.desc(),
+        )
+    )
+    if limit:
+        query = query.limit(limit)
+    return query.all()
+
+
+def _looks_like_rehash(old_hash, new_hash):
+    """Whether ``new_hash`` is CKAN re-hashing the same password.
+
+    ``User.validate_password`` upgrades a stored hash whose rounds or salt
+    size are below passlib's current defaults, which changes the hash without
+    the password changing. Recognised by exactly that: the hash we had was
+    below current parameters and the one we see now is not.
+
+    Deliberately narrow. Anything it is unsure about is treated as a real
+    password change, which restarts the rotation clock -- asking someone to
+    change their password sooner than necessary is the safe way to be wrong.
+    """
+    try:
+        if not (pbkdf2_sha512.identify(old_hash)
+                and pbkdf2_sha512.identify(new_hash)):
+            return False
+        old = pbkdf2_sha512.from_string(old_hash)
+        new = pbkdf2_sha512.from_string(new_hash)
+    except Exception:
+        return False
+
+    was_below_defaults = (
+        old.rounds < pbkdf2_sha512.default_rounds
+        or len(old.salt) < pbkdf2_sha512.default_salt_size
+    )
+    now_at_defaults = (
+        new.rounds >= pbkdf2_sha512.default_rounds
+        and len(new.salt) >= pbkdf2_sha512.default_salt_size
+    )
+    return was_below_defaults and now_at_defaults
+
+
+def _prune(user_id):
+    """Drop rows past the retained history length.
+
+    The retained hashes are old credentials, so keeping more of them than the
+    reuse check consults is a liability rather than an archive. One row is
+    always kept whatever the setting, because the rotation window is measured
+    from it.
+    """
+    keep = max(1, history_length())
+    for row in _history(user_id)[keep:]:
+        Session.delete(row)
+
+
+def record_password(user_id, password_hash, when=None, commit=True):
+    """Record a hash as this user's current password."""
+    row = UserPasswordHistory(
+        user_id=user_id,
+        password_hash=password_hash,
+        created_at=when or datetime.datetime.utcnow(),
+    )
+    Session.add(row)
+    # CKAN's session is ``autoflush=False``, so without this the new row is
+    # invisible to the query ``_prune`` runs and the history creeps one row
+    # past the configured length.
+    Session.flush()
+    _prune(user_id)
+    if commit:
+        Session.commit()
+    return row
+
+
+def sync_history(user):
+    """Reconcile the history against the live hash and return the newest row.
+
+    Returns ``None`` only for a user with no usable password hash at all --
+    an invited account that has never set one, for instance -- which has
+    nothing to rotate.
+    """
+    if user is None or not getattr(user, "password", None):
+        return None
+
+    rows = _history(user.id, limit=1)
+    latest = rows[0] if rows else None
+
+    if latest is None:
+        # First time we have seen this user. Their password is however old it
+        # is, but there is no record of when it was set, so the window starts
+        # now: locking every existing user out on the day this ships is not a
+        # security improvement.
+        return record_password(user.id, user.password)
+
+    if latest.password_hash == user.password:
+        return latest
+
+    if _looks_like_rehash(latest.password_hash, user.password):
+        # Same password, stronger storage. Keep the date.
+        latest.password_hash = user.password
+        Session.commit()
+        return latest
+
+    # Changed by something that does not go through the actions --
+    # ``ckan user setpass``, or a direct write. Treat it as a change.
+    return record_password(user.id, user.password)
+
+
+def latest_change(user):
+    """``sync_history`` memoised for the duration of the request."""
+    if not has_request_context():
+        return sync_history(user)
+    cached = getattr(g, _LATEST_ATTR, False)
+    if cached is not False:
+        return cached
+    latest = sync_history(user)
+    setattr(g, _LATEST_ATTR, latest)
+    return latest
+
+
+def is_reused(password, user):
+    """Whether ``password`` is the user's current or a recent password.
+
+    The live hash is always checked, even when the history is switched off:
+    "change your password" that accepts the same password back is not a
+    change. Each check is a full pbkdf2 verification, which is why the number
+    of them is bounded by ``history_length``.
+    """
+    if user is None:
+        return False
+
+    hashes = [getattr(user, "password", None)]
+    if history_length():
+        hashes += [row.password_hash for row in _history(user.id,
+                                                        history_length())]
+
+    for stored in hashes:
+        if not stored:
+            continue
+        try:
+            # Legacy sha1 hashes (CKAN < 2.0) are not pbkdf2 and make verify
+            # raise. They belong to passwords nobody can still be reusing
+            # deliberately, so skipping them is no loss.
+            if not pbkdf2_sha512.identify(stored):
+                continue
+            if pbkdf2_sha512.verify(password, stored):
+                return True
+        except (ValueError, TypeError):
+            continue
+    return False
+
+
+# --------------------------------------------------------------------------
+# Validator
+# --------------------------------------------------------------------------
+
+
+def _target_user(data, context):
+    """The user whose password is being set, if they already exist.
+
+    ``user_update`` puts the row in the context before validating, which is
+    the case that matters -- it is the only one where there is a history to
+    check against. The lookup by ``id``/``name`` covers callers that build
+    their own context, and returns ``None`` during ``user_create``.
+    """
+    user_obj = context.get("user_obj")
+    if user_obj is not None:
+        return user_obj
+    for field in ("id", "name"):
+        value = data.get((field,))
+        if value and not isinstance(value, Missing):
+            user = core_model.User.get(value)
+            if user is not None:
+                return user
+    return None
+
+
+def user_password_validator(key, data, errors, context):
+    """Replaces CKAN's 8-character check. Registered by name.
+
+    Errors are appended under ``('password',)`` regardless of which field is
+    being validated, matching what core does: the form templates read
+    ``errors.password1`` for the inline message but the summary is keyed on
+    ``password``, and splitting the two would put the message nowhere on the
+    registration form.
+    """
+    value = data[key]
+
+    if isinstance(value, Missing) or value is None or value == "":
+        # Absence is other validators' business: ``user_password_not_empty``
+        # on create, ``ignore_missing`` on update.
+        return
+
+    if not isinstance(value, str):
+        errors[("password",)].append(_("Passwords must be strings"))
+        return
+
+    user = _target_user(data, context)
+    identifiers = [
+        data.get(("name",)),
+        data.get(("email",)),
+        data.get(("fullname",)),
+    ]
+    if user is not None:
+        identifiers += [user.name, user.email, user.fullname]
+    identifiers = [
+        value_ for value_ in identifiers
+        if isinstance(value_, str) and value_
+    ]
+
+    failures = check_strength(value, identifiers)
+    if failures:
+        errors[("password",)].append(
+            _("Your password must {}.").format("; ".join(failures))
+        )
+        # Stop here rather than also running the reuse check: a password that
+        # fails the policy is being rejected either way, and the reuse check
+        # costs a pbkdf2 verification per stored hash.
+        return
+
+    if is_reused(value, user):
+        errors[("password",)].append(
+            _("You have used this password before. Please choose a password "
+              "you have not used on this account.")
+        )
+
+
+# --------------------------------------------------------------------------
+# Recording changes made through the actions
+# --------------------------------------------------------------------------
+
+
+def _live_hash(ident):
+    if not ident:
+        return None
+    user = core_model.User.get(ident)
+    # A plain str, so it survives the update that is about to happen to the
+    # row it came from.
+    return user.password if user is not None else None
+
+
+def _record_if_changed(ident, before, context):
+    try:
+        after = _live_hash(ident)
+        if not after or after == before:
+            return
+        user = core_model.User.get(ident)
+        # ``defer_commit`` means the caller owns the transaction: adding to it
+        # is fine, committing it is not.
+        row = record_password(user.id, after,
+                              commit=not context.get("defer_commit"))
+        if has_request_context():
+            # The memoised row for this request is now stale, and the same
+            # request goes on to render a page.
+            setattr(g, _LATEST_ATTR, row)
+    except Exception:
+        # A password that changed but went unrecorded costs the user an early
+        # rotation prompt. Failing the change itself would cost them the
+        # account.
+        log.exception("Failed to record password change for %s", ident)
+
+
+@toolkit.chained_action
+def user_create(up_func, context, data_dict):
+    """Records the password a new account starts with.
+
+    Without this the account's first history row would be written by
+    ``sync_history`` on its first request, dating the password from then
+    rather than from creation.
+    """
+    result = up_func(context, data_dict)
+    _record_if_changed(result.get("id") or result.get("name"), None, context)
+    return result
+
+
+@toolkit.chained_action
+def user_update(up_func, context, data_dict):
+    """Records a password change made through the API, forms or reset flow.
+
+    Detected by the hash changing rather than by ``password`` appearing in the
+    payload: a sysadmin importing an account supplies ``password_hash``
+    directly, and CKAN's own reset flow rebuilds the whole user dict.
+    """
+    before = _live_hash(data_dict.get("id"))
+    result = up_func(context, data_dict)
+    _record_if_changed(result.get("id") or data_dict.get("id"), before,
+                       context)
+    return result
+
+
+# --------------------------------------------------------------------------
+# Rotation
+# --------------------------------------------------------------------------
+
+
+def expires_at(user):
+    """When this user's password expires, or ``None`` if it cannot."""
+    days = expiry_days()
+    if not days:
+        return None
+    latest = latest_change(user)
+    if latest is None:
+        return None
+    return latest.created_at + datetime.timedelta(days=days)
+
+
+def days_until_expiry(user):
+    """Days left, negative once expired, or ``None`` if rotation is off.
+
+    ``timedelta.days`` floors, which is what is wanted at both ends: a
+    password with 12 hours left reports 0 -- "expires today" -- and one that
+    expired an hour ago reports -1 rather than 0, so a single ``< 0`` test
+    means expired.
+    """
+    expiry = expires_at(user)
+    if expiry is None:
+        return None
+    return (expiry - datetime.datetime.utcnow()).days
+
+
+def is_expired(user):
+    remaining = days_until_expiry(user)
+    return remaining is not None and remaining < 0
+
+
+def enforce_rotation():
+    """Redirect to the profile form while the user's password is expired.
+
+    Returns ``None`` to let the request through.
+
+    Nothing here may raise: this runs before every view, so an error in the
+    policy would take the whole site down rather than one page.
+    """
+    try:
+        return _enforce_rotation()
+    except Exception:
+        log.exception("Password rotation check failed; allowing the request")
+        return None
+
+
+def _enforce_rotation():
+    if not has_request_context():
+        return None
+    if not expiry_days() and not warn_days():
+        return None
+
+    user = toolkit.current_user
+    if user is None or getattr(user, "is_anonymous", True):
+        return None
+    # A pending invitee is mid-way through setting their first password and a
+    # deleted account is on its way out; neither has a rotation to enforce.
+    if getattr(user, "state", None) != "active":
+        return None
+
+    # The action API is exempt -- see the module docstring.
+    if toolkit.request.path.startswith("/api/"):
+        return None
+
+    endpoint = toolkit.request.endpoint or ""
+    blueprint = endpoint.split(".")[0]
+    if endpoint in ALLOWED_WHILE_EXPIRED or blueprint in ("static",
+                                                          "webassets"):
+        return None
+
+    remaining = days_until_expiry(user)
+    if remaining is None:
+        return None
+
+    if remaining >= 0:
+        _warn_if_expiring(user, remaining)
+        return None
+
+    # The rules themselves are on the page this redirects to, so the message
+    # says why rather than repeating all of them.
+    toolkit.h.flash_error(
+        _("Your password is more than {days} days old. Choose a new one "
+          "before continuing.").format(days=expiry_days())
+    )
+    return toolkit.redirect_to(CHANGE_PASSWORD_ENDPOINT, id=user.name)
+
+
+def _warn_if_expiring(user, remaining):
+    """Flash a warning as expiry approaches, once per browser session.
+
+    Once per session rather than once per page: a banner on every page for a
+    fortnight trains people to ignore banners.
+    """
+    window = warn_days()
+    if not window or remaining > window:
+        return
+
+    expiry = expires_at(user)
+    marker = expiry.date().isoformat() if expiry else str(remaining)
+    try:
+        if session.get(_WARNED_SESSION_KEY) == marker:
+            return
+        session[_WARNED_SESSION_KEY] = marker
+    except Exception:
+        # No usable session (an unsigned-cookie edge case): warning once is
+        # still better than not warning.
+        log.debug("Could not record password expiry warning in the session")
+
+    if remaining == 0:
+        message = _("Your password expires today. Change it to avoid losing "
+                    "access.")
+    else:
+        message = _("Your password expires in {days} day(s). You will not be "
+                    "able to use the site until you change it.").format(
+                        days=remaining)
+    toolkit.h.flash_notice(message)
+
+
+# --------------------------------------------------------------------------
+# Blueprint
+# --------------------------------------------------------------------------
+
+# Carries no routes. It exists only to hang the rotation check off
+# ``before_app_request``, which is the one hook that runs before every view
+# regardless of which extension owns the view or where this plugin sits in
+# ``ckan.plugins``.
+blueprint = Blueprint("sse_password_policy", __name__)
+
+
+@blueprint.before_app_request
+def check_password_rotation():
+    return enforce_rotation()

--- a/ckanext/sse/password_policy.py
+++ b/ckanext/sse/password_policy.py
@@ -1,5 +1,39 @@
 """Password strength, reuse and rotation policy.
 
+Implements SSE's *Standard for Identification and Authentication* IA-5 and
+IA-5.1 as far as a CKAN portal can. Where the standard is written for Active
+Directory the nearest portal equivalent is used, and where a requirement is
+organisational rather than technical it is called out below rather than
+quietly dropped.
+
+IA-5.1, passphrase requirements, and where each one lives:
+
+===================================================== ======================
+12 characters or more, 15 for administration accounts ``check_strength``
+Not on a list of common/expected/compromised passwords ``_blocklist``
+Not contain any part of the username                  ``check_strength``
+Not be a single dictionary word                       ``_blocklist`` (partial)
+Not more than 4 repeating characters or digits        ``_has_repeat``
+No ascending or descending number sequences           ``_has_sequence``
+Not changed incrementally (Welcome100, Welcome101)    ``is_incremental``
+Not the same as any of the last 8 passwords           ``is_reused``
+New password on account recovery                      CKAN's reset flow
+Stored with an approved salted hash                   CKAN's pbkdf2-sha512
+===================================================== ======================
+
+IA-5 f, rotation: 365 days for non-privileged users, 60 for privileged ones.
+"Privileged" is read as a CKAN sysadmin; organisation admins are not system
+administrators and are treated as ordinary users.
+
+Deliberately *not* enforced here, because nothing in a CKAN extension can:
+passwords transmitted only under TLS (IA-5.1 c, an ingress concern); admin
+accounts not sharing a password with the holder's AD account (f); passphrases
+not reused outside SSE. Note also that the standard prefers passphrases and
+the "three random word" approach, so there is no character-class requirement
+-- demanding an uppercase, a digit and a symbol would push users away from the
+thing the standard asks for. ``ckanext.sse.password.require_character_classes``
+turns one on for a deployment that wants it.
+
 Three separate controls, all driven from this module:
 
 * **Strength** -- CKAN's own rule is "8 characters or longer" and nothing
@@ -69,18 +103,26 @@ updated in place, keeping the original date. See ``_looks_like_rehash``.
 Configuration (all optional)
 ----------------------------
 
-============================================== ==========================
-``ckanext.sse.password.min_length``            12
-``ckanext.sse.password.max_length``            128
-``ckanext.sse.password.history_length``        5 (0 disables the reuse check)
-``ckanext.sse.password.expiry_days``           90 (0 disables rotation)
-``ckanext.sse.password.warn_days``             14 (0 disables the warning)
-``ckanext.sse.password.extra_blocklist``       extra banned words
-============================================== ==========================
+===================================================== ======================
+``ckanext.sse.password.min_length``                   12
+``ckanext.sse.password.privileged_min_length``        15
+``ckanext.sse.password.max_length``                   128
+``ckanext.sse.password.history_length``               8 (0: current only)
+``ckanext.sse.password.expiry_days``                  365 (0 disables)
+``ckanext.sse.password.privileged_expiry_days``       60 (0 disables)
+``ckanext.sse.password.warn_days``                    14 (0 disables)
+``ckanext.sse.password.max_repeat``                   4
+``ckanext.sse.password.max_digit_sequence``           2
+``ckanext.sse.password.max_letter_sequence``          3
+``ckanext.sse.password.require_character_classes``    false
+``ckanext.sse.password.blocklist_file``               path, one word per line
+``ckanext.sse.password.extra_blocklist``              extra banned words
+===================================================== ======================
 """
 
 import datetime
 import logging
+import os
 import re
 import secrets
 import string
@@ -100,23 +142,47 @@ log = logging.getLogger(__name__)
 
 _ = toolkit._
 
+# IA-5.1 g: "passphrases (12 characters or more)", and "Administration
+# accounts passphrases should be minimum of 15 characters".
 DEFAULT_MIN_LENGTH = 12
+DEFAULT_PRIVILEGED_MIN_LENGTH = 15
 
 # Not tidiness: the candidate is fed to pbkdf2 once per history entry plus
 # once to store it, and pbkdf2 cost is linear in input length. Without a cap a
 # multi-megabyte "password" is a cheap way to tie up a worker.
 DEFAULT_MAX_LENGTH = 128
 
-DEFAULT_HISTORY_LENGTH = 5
-DEFAULT_EXPIRY_DAYS = 90
+# IA-5.1: "Not be the same as any of the last 8 passwords".
+DEFAULT_HISTORY_LENGTH = 8
+
+# IA-5 f: 365 days for non-privileged users, 60 for privileged ones.
+DEFAULT_EXPIRY_DAYS = 365
+DEFAULT_PRIVILEGED_EXPIRY_DAYS = 60
+
 DEFAULT_WARN_DAYS = 14
 
-# A run of this many identical characters is rejected, so "aaa" is out.
-MAX_REPEAT = 3
+# IA-5.1: "Not have more than 4 repeating characters or digits", so a run of
+# five is the first one rejected.
+DEFAULT_MAX_REPEAT = 4
 
-# A run of this many consecutive codepoints is rejected, so "1234", "abcd" and
-# "9876" are out.
-MAX_SEQUENCE = 4
+# IA-5.1: "Not contain ascending or descending number sequences". No length is
+# given, so three is taken as the shortest run that is recognisably a sequence
+# -- two consecutive digits happen by accident in any date.
+DEFAULT_MAX_DIGIT_SEQUENCE = 2
+
+# The standard names number sequences only. Letter runs are held to four
+# because "abcd" is the same idea and costs nothing to catch.
+DEFAULT_MAX_LETTER_SEQUENCE = 3
+
+# How far either side of the number in a password to look when deciding
+# whether it is the previous password with the number bumped.
+DEFAULT_INCREMENT_WINDOW = 3
+
+# IA-5.1: "For other Service accounts, passphrases must be set to 20
+# characters or more". CKAN has no service accounts as such, but the accounts
+# the frontend creates for itself are the nearest thing, and their passwords
+# are generated rather than typed, so length is free.
+DEFAULT_SERVICE_ACCOUNT_LENGTH = 20
 
 # Symbols used when generating a password. Quotes, backslashes and spaces are
 # left out: generated passwords get passed through shells, JSON bodies and
@@ -210,6 +276,11 @@ _LATEST_ATTR = "sse_password_latest"
 # so the warning appears once per browser session rather than on every page.
 _WARNED_SESSION_KEY = "sse_password_expiry_warned"
 
+# The blocklist file, keyed on its path and mtime. Module level rather than
+# per-request: the file is the same for every worker and rereading a
+# compromised-password corpus on each password change would be wasteful.
+_BLOCKLIST_CACHE = {"stamp": None, "words": frozenset()}
+
 
 # --------------------------------------------------------------------------
 # Configuration
@@ -227,14 +298,30 @@ def _int_config(key, default, minimum=0):
     return max(minimum, value)
 
 
-def min_length():
+def is_privileged(user):
+    """Whether the standard's "administration account" rules apply.
+
+    A CKAN sysadmin. Organisation admins administer a publisher's datasets,
+    not the system, so they are held to the ordinary user rules.
+    """
+    return bool(user is not None and getattr(user, "sysadmin", False))
+
+
+def min_length(privileged=False):
+    if privileged:
+        return max(
+            _int_config("ckanext.sse.password.privileged_min_length",
+                        DEFAULT_PRIVILEGED_MIN_LENGTH, minimum=8),
+            _int_config("ckanext.sse.password.min_length",
+                        DEFAULT_MIN_LENGTH, minimum=8),
+        )
     return _int_config("ckanext.sse.password.min_length",
                        DEFAULT_MIN_LENGTH, minimum=8)
 
 
 def max_length():
     return max(
-        min_length(),
+        min_length(privileged=True),
         _int_config("ckanext.sse.password.max_length", DEFAULT_MAX_LENGTH,
                     minimum=8),
     )
@@ -246,8 +333,11 @@ def history_length():
                        DEFAULT_HISTORY_LENGTH)
 
 
-def expiry_days():
+def expiry_days(privileged=False):
     """Rotation window in days. 0 disables rotation entirely."""
+    if privileged:
+        return _int_config("ckanext.sse.password.privileged_expiry_days",
+                           DEFAULT_PRIVILEGED_EXPIRY_DAYS)
     return _int_config("ckanext.sse.password.expiry_days",
                        DEFAULT_EXPIRY_DAYS)
 
@@ -257,9 +347,83 @@ def warn_days():
     return _int_config("ckanext.sse.password.warn_days", DEFAULT_WARN_DAYS)
 
 
+def max_repeat():
+    """Longest run of one repeated character that is still allowed."""
+    return _int_config("ckanext.sse.password.max_repeat",
+                       DEFAULT_MAX_REPEAT, minimum=1)
+
+
+def max_digit_sequence():
+    """Longest run of consecutive digits that is still allowed."""
+    return _int_config("ckanext.sse.password.max_digit_sequence",
+                       DEFAULT_MAX_DIGIT_SEQUENCE, minimum=1)
+
+
+def max_letter_sequence():
+    """Longest run of consecutive letters that is still allowed."""
+    return _int_config("ckanext.sse.password.max_letter_sequence",
+                       DEFAULT_MAX_LETTER_SEQUENCE, minimum=1)
+
+
+def require_character_classes():
+    """Whether to demand upper, lower, digit and symbol.
+
+    Off by default: the standard asks for passphrases and the "three random
+    word" approach, and a character-class rule works against both.
+    """
+    return toolkit.asbool(
+        toolkit.config.get("ckanext.sse.password.require_character_classes",
+                           False)
+    )
+
+
 def _word_list(configured, builtin):
     words = re.split(r"[,\s]+", "{} {}".format(builtin, configured or "").strip())
     return {word.lower() for word in words if len(word) > 3}
+
+
+def _blocklist_file_words():
+    """The maintained blocklist, read from disk and cached on its mtime.
+
+    IA-5.1 a and b call for a list of common, expected and compromised
+    passwords that is "updated continually", which a list baked into this
+    module cannot be. Point ``ckanext.sse.password.blocklist_file`` at a file
+    of one word per line -- a compromised-password corpus, a dictionary, or
+    both -- and replacing it is a deployment step rather than a release.
+
+    Cached on (path, mtime, size) so a replaced file is picked up without a
+    restart and an unchanged one is not re-read on every password change.
+    """
+    path = (toolkit.config.get("ckanext.sse.password.blocklist_file", "")
+            or "").strip()
+    if not path:
+        return frozenset()
+
+    try:
+        stat = os.stat(path)
+        stamp = (path, stat.st_mtime, stat.st_size)
+    except OSError:
+        log.warning("Cannot read ckanext.sse.password.blocklist_file %r", path)
+        return frozenset()
+
+    cached = _BLOCKLIST_CACHE.get("stamp")
+    if cached == stamp:
+        return _BLOCKLIST_CACHE["words"]
+
+    try:
+        with open(path, encoding="utf-8", errors="ignore") as handle:
+            words = frozenset(
+                line.strip().lower() for line in handle
+                if len(line.strip()) > 3 and not line.startswith("#")
+            )
+    except OSError:
+        log.warning("Cannot read ckanext.sse.password.blocklist_file %r", path)
+        return frozenset()
+
+    _BLOCKLIST_CACHE["stamp"] = stamp
+    _BLOCKLIST_CACHE["words"] = words
+    log.info("Loaded %s password blocklist entries from %s", len(words), path)
+    return words
 
 
 def _banned_substrings():
@@ -269,7 +433,13 @@ def _banned_substrings():
 
 
 def _banned_whole():
-    return _word_list("", BANNED_WHOLE)
+    """Words banned as the whole password, give or take a couple of letters.
+
+    The file lives here rather than in the substring list because a
+    compromised-password corpus is full of ordinary words, and banning those
+    as substrings would ban the passphrases the standard asks for.
+    """
+    return _word_list("", BANNED_WHOLE) | _blocklist_file_words()
 
 
 # --------------------------------------------------------------------------
@@ -277,37 +447,63 @@ def _banned_whole():
 # --------------------------------------------------------------------------
 
 
-def policy_rules():
+def policy_rules(privileged=None):
     """The policy in words, for error messages and for the forms.
 
     Generated from the live configuration rather than written out twice: a
     hint that disagrees with the validator is worse than no hint.
+
+    ``privileged`` defaults to whoever is signed in, so a sysadmin editing
+    their own profile is shown the 15-character rule that will actually be
+    applied to them.
     """
+    if privileged is None:
+        privileged = is_privileged(_current_user())
+
     rules = [
         _("be between {min} and {max} characters long").format(
-            min=min_length(), max=max_length()
+            min=min_length(privileged), max=max_length()
         ),
-        _("contain an uppercase letter, a lowercase letter, a digit and a "
-          "symbol"),
-        _("not repeat the same character {n} or more times in a row").format(
-            n=MAX_REPEAT
+        # The standard prefers passphrases, so the hint suggests one rather
+        # than leaving people to invent something that merely passes.
+        _("preferably be a passphrase of three or more random words"),
+    ]
+    if require_character_classes():
+        rules.append(
+            _("contain an uppercase letter, a lowercase letter, a digit and a "
+              "symbol")
+        )
+    rules += [
+        _("not repeat the same character more than {n} times in a row").format(
+            n=max_repeat()
         ),
-        _("not contain {n} or more sequential characters, such as 1234 or "
-          "abcd").format(n=MAX_SEQUENCE),
-        _("not be based on a common password, your username, your full name "
-          "or your email address"),
+        _("not contain ascending or descending sequences, such as 123 or "
+          "abcd"),
+        _("not be a common password, a single dictionary word, or contain "
+          "your username, full name or email address"),
     ]
     if history_length():
         rules.append(
-            _("not be one of your {n} previous passwords").format(
-                n=history_length()
+            _("not be one of your {n} previous passwords, nor one of them "
+              "with the number changed").format(n=history_length())
+        )
+    if expiry_days(privileged):
+        rules.append(
+            _("be changed at least every {n} days").format(
+                n=expiry_days(privileged)
             )
         )
-    if expiry_days():
-        rules.append(
-            _("be changed at least every {n} days").format(n=expiry_days())
-        )
     return rules
+
+
+def _current_user():
+    """The signed-in user, or ``None`` outside a request."""
+    if not has_request_context():
+        return None
+    user = toolkit.current_user
+    if user is None or getattr(user, "is_anonymous", True):
+        return None
+    return user
 
 
 def _normalise(password, undo_substitutions):
@@ -319,30 +515,53 @@ def _normalise(password, undo_substitutions):
 
 
 def _has_repeat(password):
-    return re.search(r"(.)\1{%d,}" % (MAX_REPEAT - 1), password) is not None
+    """Whether one character repeats more times in a row than allowed."""
+    return re.search(r"(.)\1{%d,}" % max_repeat(), password) is not None
 
 
 def _has_sequence(password):
     """Whether the password contains a run of consecutive codepoints.
 
-    Catches ``1234`` and ``abcd`` in either direction. Codepoint arithmetic
+    Catches ``123`` and ``abcd`` in either direction. Codepoint arithmetic
     rather than a keyboard map: ``qwerty`` and friends are handled by the word
-    list, and the point here is the numeric and alphabetic runs people reach
-    for to satisfy a character-class rule.
+    list, and the point here is the ascending and descending runs the standard
+    names.
+
+    Digits and letters are counted separately because the standard is explicit
+    about number sequences and silent about letters, so digits are held to the
+    shorter run.
     """
-    run = 1
+    digits = max_digit_sequence()
+    letters = max_letter_sequence()
+
+    start = 0
     step = 0
-    for previous, current in zip(password, password[1:]):
-        delta = ord(current) - ord(previous)
-        if delta in (1, -1) and (step == 0 or delta == step):
+    for index in range(1, len(password)):
+        delta = ord(password[index]) - ord(password[index - 1])
+        if delta in (1, -1) and step in (0, delta):
             step = delta
-            run += 1
-            if run >= MAX_SEQUENCE:
-                return True
+            continue
+        if _sequence_too_long(password[start:index], digits, letters):
+            return True
+        # A pair that broke the run because it runs the other way still starts
+        # a run of its own.
+        if delta in (1, -1):
+            start, step = index - 1, delta
         else:
-            step = delta if delta in (1, -1) else 0
-            run = 2 if step else 1
-    return False
+            start, step = index, 0
+    return _sequence_too_long(password[start:], digits, letters)
+
+
+def _sequence_too_long(run, digits, letters):
+    """Whether one run of consecutive codepoints is over its limit.
+
+    A mixed run ("yz01") is neither digits nor letters and is left alone --
+    nobody types that as a sequence, and the standard is about the ones people
+    do type.
+    """
+    if len(run) > digits and run.isdigit():
+        return True
+    return len(run) > letters and run.isalpha()
 
 
 def _identifier_words(*values):
@@ -362,7 +581,7 @@ def _identifier_words(*values):
     return words
 
 
-def check_strength(password, identifiers=()):
+def check_strength(password, identifiers=(), privileged=False):
     """Every way ``password`` fails the policy, as a list of phrases.
 
     Phrases, not sentences: the caller joins them into one message because
@@ -372,40 +591,41 @@ def check_strength(password, identifiers=()):
     if not isinstance(password, str):
         return [_("be a string")]
 
+    minimum = min_length(privileged)
     failures = []
-    if len(password) < min_length():
+    if len(password) < minimum:
         failures.append(
-            _("be at least {n} characters long").format(n=min_length())
+            _("be at least {n} characters long").format(n=minimum)
         )
     if len(password) > max_length():
         failures.append(
             _("be no more than {n} characters long").format(n=max_length())
         )
 
-    missing = []
-    if not any(char.islower() for char in password):
-        missing.append(_("a lowercase letter"))
-    if not any(char.isupper() for char in password):
-        missing.append(_("an uppercase letter"))
-    if not any(char.isdigit() for char in password):
-        missing.append(_("a digit"))
-    # Anything that is not a letter or a digit counts, including a space, so
-    # passphrases are not pushed towards punctuation soup.
-    if not any(not char.isalnum() for char in password):
-        missing.append(_("a symbol"))
-    if missing:
-        failures.append(_("contain {}").format(", ".join(missing)))
+    if require_character_classes():
+        missing = []
+        if not any(char.islower() for char in password):
+            missing.append(_("a lowercase letter"))
+        if not any(char.isupper() for char in password):
+            missing.append(_("an uppercase letter"))
+        if not any(char.isdigit() for char in password):
+            missing.append(_("a digit"))
+        # Anything that is not a letter or a digit counts, including a space,
+        # so passphrases are not pushed towards punctuation soup.
+        if not any(not char.isalnum() for char in password):
+            missing.append(_("a symbol"))
+        if missing:
+            failures.append(_("contain {}").format(", ".join(missing)))
 
     if _has_repeat(password):
         failures.append(
-            _("not repeat the same character {n} or more times in a "
-              "row").format(n=MAX_REPEAT)
+            _("not repeat the same character more than {n} times in a "
+              "row").format(n=max_repeat())
         )
     if _has_sequence(password):
         failures.append(
-            _("not contain {n} or more sequential characters").format(
-                n=MAX_SEQUENCE
-            )
+            _("not contain ascending or descending sequences such as 123 or "
+              "abcd")
         )
 
     # Both forms are checked: the plain one catches "Password123", the
@@ -440,14 +660,17 @@ def generate_password(length=None):
     Candidates are rejected by ``check_strength`` rather than assembled to
     satisfy each rule, so the generator cannot drift away from the policy --
     if a rule is added, this keeps producing valid passwords without being
-    touched.
+    touched. Checked against the privileged minimum whoever it is for, which
+    also puts it at the 20 characters the standard asks of service accounts.
     """
-    length = max(length or min_length() + 8, min_length())
-    length = min(length, max_length())
+    floor = max(min_length(privileged=True), DEFAULT_SERVICE_ACCOUNT_LENGTH)
+    length = min(max(length or floor, floor), max_length())
     alphabet = string.ascii_letters + string.digits + GENERATED_SYMBOLS
     while True:
-        candidate = "".join(secrets.choice(alphabet) for _unused in range(length))
-        if not check_strength(candidate):
+        candidate = "".join(
+            secrets.choice(alphabet) for _unused in range(length)
+        )
+        if not check_strength(candidate, privileged=True):
             return candidate
 
 
@@ -598,20 +821,80 @@ def is_reused(password, user):
         hashes += [row.password_hash for row in _history(user.id,
                                                         history_length())]
 
-    for stored in hashes:
-        if not stored:
-            continue
-        try:
-            # Legacy sha1 hashes (CKAN < 2.0) are not pbkdf2 and make verify
-            # raise. They belong to passwords nobody can still be reusing
-            # deliberately, so skipping them is no loss.
-            if not pbkdf2_sha512.identify(stored):
+    return any(_matches(password, stored) for stored in hashes)
+
+
+def _matches(password, stored):
+    """Whether ``password`` is the one behind ``stored``, tolerating junk."""
+    if not stored:
+        return False
+    try:
+        # Legacy sha1 hashes (CKAN < 2.0) are not pbkdf2 and make verify
+        # raise. They belong to passwords nobody can still be reusing
+        # deliberately, so skipping them is no loss.
+        if not pbkdf2_sha512.identify(stored):
+            return False
+        return bool(pbkdf2_sha512.verify(password, stored))
+    except (ValueError, TypeError):
+        return False
+
+
+def _increment_window():
+    return _int_config("ckanext.sse.password.increment_window",
+                       DEFAULT_INCREMENT_WINDOW)
+
+
+def incremental_variants(password):
+    """Passwords that ``password`` could be a numeric bump of.
+
+    IA-5.1 forbids a password being "changed incrementally on password
+    change, e.g. Welcome100, Welcome101, Welcome102". Only the hashes of
+    previous passwords are stored, so the previous one cannot be read and
+    compared -- instead the candidates it *would* have been are reconstructed
+    from the new password and each is verified against the stored hash.
+
+    The last run of digits anywhere in the password is the one varied, so
+    "Summer2024!" catches "Summer2023!" as well as the trailing-number case
+    the standard spells out. Both zero-padded and bare forms are produced,
+    since "Welcome09" -> "Welcome10" changes the width. Dropping the digits
+    entirely covers "Welcome" -> "Welcome1".
+    """
+    runs = list(re.finditer(r"\d+", password))
+    if not runs:
+        return []
+
+    run = runs[-1]
+    prefix, digits, suffix = (
+        password[:run.start()], run.group(), password[run.end():]
+    )
+    value = int(digits)
+    width = len(digits)
+
+    variants = {prefix + suffix}
+    for delta in range(1, _increment_window() + 1):
+        for candidate in (value - delta, value + delta):
+            if candidate < 0:
                 continue
-            if pbkdf2_sha512.verify(password, stored):
-                return True
-        except (ValueError, TypeError):
-            continue
-    return False
+            variants.add(prefix + str(candidate) + suffix)
+            variants.add(prefix + str(candidate).zfill(width) + suffix)
+
+    variants.discard(password)
+    return sorted(variants)
+
+
+def is_incremental(password, user):
+    """Whether ``password`` is the user's current password with a bumped number.
+
+    Checked against the current password alone, not the whole history: the
+    standard's wording is about a password being changed incrementally *on
+    password change*, and each extra hash multiplies the number of pbkdf2
+    verifications by the size of the candidate set.
+    """
+    stored = getattr(user, "password", None) if user is not None else None
+    if not stored:
+        return False
+    return any(_matches(variant, stored)
+               for variant in incremental_variants(password))
 
 
 # --------------------------------------------------------------------------
@@ -672,20 +955,35 @@ def user_password_validator(key, data, errors, context):
         if isinstance(value_, str) and value_
     ]
 
-    failures = check_strength(value, identifiers)
+    # A sysadmin is held to the administration-account minimum, whether the
+    # flag is already on the row or is being granted in this very call.
+    granting = data.get(("sysadmin",))
+    if granting is None or isinstance(granting, Missing):
+        granting = False
+    privileged = is_privileged(user) or toolkit.asbool(granting)
+
+    failures = check_strength(value, identifiers, privileged=privileged)
     if failures:
         errors[("password",)].append(
             _("Your password must {}.").format("; ".join(failures))
         )
-        # Stop here rather than also running the reuse check: a password that
-        # fails the policy is being rejected either way, and the reuse check
-        # costs a pbkdf2 verification per stored hash.
+        # Stop here rather than also running the reuse checks: a password that
+        # fails the policy is being rejected either way, and those cost a
+        # pbkdf2 verification apiece.
         return
 
     if is_reused(value, user):
         errors[("password",)].append(
             _("You have used this password before. Please choose a password "
               "you have not used on this account.")
+        )
+        return
+
+    if is_incremental(value, user):
+        errors[("password",)].append(
+            _("This is your current password with the number changed. Please "
+              "choose a different password rather than an increment of the "
+              "one it replaces.")
         )
 
 
@@ -759,7 +1057,7 @@ def user_update(up_func, context, data_dict):
 
 def expires_at(user):
     """When this user's password expires, or ``None`` if it cannot."""
-    days = expiry_days()
+    days = expiry_days(is_privileged(user))
     if not days:
         return None
     latest = latest_change(user)
@@ -805,11 +1103,11 @@ def enforce_rotation():
 def _enforce_rotation():
     if not has_request_context():
         return None
-    if not expiry_days() and not warn_days():
-        return None
 
     user = toolkit.current_user
     if user is None or getattr(user, "is_anonymous", True):
+        return None
+    if not expiry_days(is_privileged(user)) and not warn_days():
         return None
     # A pending invitee is mid-way through setting their first password and a
     # deleted account is on its way out; neither has a rotation to enforce.
@@ -838,7 +1136,8 @@ def _enforce_rotation():
     # says why rather than repeating all of them.
     toolkit.h.flash_error(
         _("Your password is more than {days} days old. Choose a new one "
-          "before continuing.").format(days=expiry_days())
+          "before continuing.").format(
+              days=expiry_days(is_privileged(user)))
     )
     return toolkit.redirect_to(CHANGE_PASSWORD_ENDPOINT, id=user.name)
 

--- a/ckanext/sse/plugin.py
+++ b/ckanext/sse/plugin.py
@@ -8,7 +8,8 @@ import logging
 from ckanext.sse import action, auth
 import ckan.authz
 from ckanext.sse.blueprints import dataset, request_access_dashboard, admin, data_reuse
-from .model import PackageAccessRequest, FormResponse
+from ckanext.sse import password_policy
+from .model import PackageAccessRequest, FormResponse, UserPasswordHistory
 import ckanext.sse.activity as activity
 from ckanext.sse.helpers import (
     is_org_admin_by_package_id,
@@ -73,6 +74,8 @@ class SsePlugin(plugins.SingletonPlugin):
             PackageAccessRequest.__table__.create(meta.engine)
         if not FormResponse.__table__.exists(meta.engine):
             FormResponse.__table__.create(meta.engine)
+        if not UserPasswordHistory.__table__.exists(meta.engine):
+            UserPasswordHistory.__table__.create(meta.engine)
 
     # ITemplateHelpers
     def get_helpers(self):
@@ -80,6 +83,7 @@ class SsePlugin(plugins.SingletonPlugin):
                     'is_org_admin_by_package_id': is_org_admin_by_package_id,
         'is_admin_of_any_org': is_admin_of_any_org,
         'get_data_reuse_field_labels': get_data_reuse_field_labels,
+        'sse_password_policy_rules': password_policy.policy_rules,
         }
 
     # IPermissionLabels
@@ -120,7 +124,15 @@ class SsePlugin(plugins.SingletonPlugin):
 
     # IBlueprint
     def get_blueprint(self):
-        return [dataset.blueprint, *request_access_dashboard.get_blueprints(), admin.blueprint, data_reuse.blueprint]
+        return [
+            dataset.blueprint,
+            *request_access_dashboard.get_blueprints(),
+            admin.blueprint,
+            data_reuse.blueprint,
+            # Routeless -- it carries the password rotation check, which has to
+            # run before every view.
+            password_policy.blueprint,
+        ]
 
     # IConfigurer
     def update_config(self, config_):
@@ -217,6 +229,9 @@ class SsePlugin(plugins.SingletonPlugin):
             "ib1_trust_framework_validator": ib1_trust_framework_validator,
             "ib1_sensitivity_class_validator": ib1_sensitivity_class_validator,
             "ib1_dataset_assurance_validator": ib1_dataset_assurance_validator,
+            # Shadows CKAN's own validator of the same name, which is how the
+            # password policy reaches every schema that sets a password.
+            "user_password_validator": password_policy.user_password_validator,
         }
 
     # IActions
@@ -240,7 +255,11 @@ class SsePlugin(plugins.SingletonPlugin):
             "data_reuse_update": action.data_reuse_update,
             "data_reuse_patch": action.data_reuse_patch,
             "data_reuse_delete": action.data_reuse_delete,
-            "resources_stats": action.resources_stats
+            "resources_stats": action.resources_stats,
+            # Chained: they only record when a password changed, so the
+            # rotation window has something to measure from.
+            "user_create": password_policy.user_create,
+            "user_update": password_policy.user_update,
         }
 
     # IAuthFunctions

--- a/ckanext/sse/plugin.py
+++ b/ckanext/sse/plugin.py
@@ -8,7 +8,7 @@ import logging
 from ckanext.sse import action, auth
 import ckan.authz
 from ckanext.sse.blueprints import dataset, request_access_dashboard, admin, data_reuse
-from ckanext.sse import password_policy
+from ckanext.sse import cli, login_throttle, password_policy, session_policy
 from .model import PackageAccessRequest, FormResponse, UserPasswordHistory
 import ckanext.sse.activity as activity
 from ckanext.sse.helpers import (
@@ -44,6 +44,7 @@ class SsePlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.ISignal, inherit=True)
     plugins.implements(plugins.IPermissionLabels)
     plugins.implements(plugins.IResourceController, inherit=True)
+    plugins.implements(plugins.IClick)
 
     # IPermissionLabels
     def get_dataset_labels(self, dataset_obj: model.Package) -> list[str]:
@@ -129,8 +130,20 @@ class SsePlugin(plugins.SingletonPlugin):
             *request_access_dashboard.get_blueprints(),
             admin.blueprint,
             data_reuse.blueprint,
-            # Routeless -- it carries the password rotation check, which has to
-            # run before every view.
+            # The last three are routeless: they carry the access-control
+            # checks that have to run before every view. Flask runs
+            # ``before_app_request`` handlers in blueprint registration order,
+            # and the order below is load-bearing:
+            #
+            # 1. the login lockout, which only looks at anonymous submissions
+            #    of the login form and has to run before the view checks the
+            #    credentials at all;
+            # 2. the idle timeout, so a session that has already expired is
+            #    sent to the login form rather than;
+            # 3. the password rotation block, which would otherwise send a
+            #    timed-out user to a form it is about to sign them out of.
+            login_throttle.blueprint,
+            session_policy.blueprint,
             password_policy.blueprint,
         ]
 
@@ -274,7 +287,18 @@ class SsePlugin(plugins.SingletonPlugin):
 
     # ISignal
     def get_signal_subscriptions(self):
-        return signals.get_subscriptions()
+        subscriptions = {}
+        for source in (signals.get_subscriptions(),
+                       login_throttle.get_subscriptions()):
+            for signal, receivers in source.items():
+                # Merged rather than combined with ``update``, so two modules
+                # subscribing to the same signal keep both receivers.
+                subscriptions.setdefault(signal, []).extend(receivers)
+        return subscriptions
+
+    # IClick
+    def get_commands(self):
+        return cli.get_commands()
 
     # IResourceController
     def after_resource_create(self, context, data_dict):

--- a/ckanext/sse/session_policy.py
+++ b/ckanext/sse/session_policy.py
@@ -1,0 +1,157 @@
+"""Idle session timeout (AC-2.5, AC-11).
+
+AC-11 requires a device lock "after 15 minutes of inactivity", retained "until
+the user re-establishes access using established identification and
+authentication procedures"; AC-2.5 requires users to log off when they finish
+work. Both are written for a workstation. The portal cannot lock a device, so
+the control it *can* implement is the compensating one: an idle session is
+ended and the user has to sign in again.
+
+Kept separate from the password policy because it is a different control with
+a different trigger, but it runs from the same kind of ``before_app_request``
+handler and must run *before* the password rotation check -- a session that
+has already timed out should be sent to the login form, not told to change its
+password.
+
+Only signed-in browser sessions are affected. Anonymous browsing has no
+session to end, and the action API is exempt for the same reason it is exempt
+from rotation: an API token is a separate credential, and a client presenting
+one is not idle at a screen.
+
+The last-seen stamp is only rewritten once a minute. Beaker sends a
+``Set-Cookie`` whenever the session changes, so stamping every request would
+add one to every response on the site, including every asset.
+
+Configuration
+-------------
+
+=============================================== ==========================
+``ckanext.sse.session.idle_timeout_minutes``    15 (0 disables)
+=============================================== ==========================
+"""
+
+import logging
+import time
+
+from flask import Blueprint, has_request_context
+from flask_login import logout_user
+
+import ckan.plugins.toolkit as toolkit
+from ckan.common import session
+
+from ckanext.sse.audit import emit_audit_log
+
+log = logging.getLogger(__name__)
+
+_ = toolkit._
+
+# AC-11 a: "initiating a device lock after 15 minutes of inactivity".
+DEFAULT_IDLE_TIMEOUT_MINUTES = 15
+
+# How stale the stamp may get before it is rewritten. Anything below the
+# timeout is safe; a minute keeps the write rate down without meaningfully
+# shortening the window.
+STAMP_INTERVAL_SECONDS = 60
+
+SESSION_KEY = "sse_last_seen"
+
+
+def idle_timeout_seconds():
+    """The idle window in seconds. 0 disables the timeout."""
+    raw = toolkit.config.get("ckanext.sse.session.idle_timeout_minutes",
+                             DEFAULT_IDLE_TIMEOUT_MINUTES)
+    try:
+        minutes = toolkit.asint(raw)
+    except (ValueError, TypeError):
+        log.warning("Ignoring invalid ckanext.sse.session."
+                    "idle_timeout_minutes %r, using %s", raw,
+                    DEFAULT_IDLE_TIMEOUT_MINUTES)
+        minutes = DEFAULT_IDLE_TIMEOUT_MINUTES
+    return max(0, minutes) * 60
+
+
+def enforce_idle_timeout():
+    """End a session that has been idle too long.
+
+    Returns a redirect to the login page when the session is ended, ``None``
+    otherwise. Nothing here may raise: it runs before every request.
+    """
+    try:
+        return _enforce_idle_timeout()
+    except Exception:
+        log.exception("Idle session check failed; allowing the request")
+        return None
+
+
+def _enforce_idle_timeout():
+    timeout = idle_timeout_seconds()
+    if not timeout or not has_request_context():
+        return None
+
+    user = toolkit.current_user
+    if user is None or getattr(user, "is_anonymous", True):
+        return None
+
+    if toolkit.request.path.startswith("/api/"):
+        return None
+
+    # Assets are skipped so that the request that gets the message is the
+    # page the user was looking at, not the stylesheet next to it.
+    blueprint = (toolkit.request.endpoint or "").split(".")[0]
+    if blueprint in ("static", "webassets", "_debug_toolbar"):
+        return None
+
+    now = int(time.time())
+    try:
+        last_seen = session.get(SESSION_KEY)
+    except Exception:
+        # No usable session, so there is no idle window to measure.
+        return None
+
+    if last_seen and now - int(last_seen) > timeout:
+        return _end_session(user, timeout)
+
+    if not last_seen or now - int(last_seen) > STAMP_INTERVAL_SECONDS:
+        try:
+            session[SESSION_KEY] = now
+        except Exception:
+            log.debug("Could not stamp the session activity time")
+    return None
+
+
+def _end_session(user, timeout):
+    name = getattr(user, "name", None)
+    emit_audit_log(
+        action="user_logout",
+        status="success",
+        user_name=name,
+        user_id=getattr(user, "id", None),
+        message="Session for {} ended after {} seconds idle".format(
+            name or "unknown", timeout),
+        reason="idle_timeout",
+        idle_timeout_seconds=timeout,
+    )
+
+    logout_user()
+    # Not ``session.clear()``: the flash below has to survive into the next
+    # request, and flask-login has already removed what identifies the user.
+    try:
+        session.pop(SESSION_KEY, None)
+    except Exception:
+        pass
+
+    toolkit.h.flash_notice(
+        _("You were signed out after {minutes} minutes of inactivity. "
+          "Please sign in again.").format(minutes=timeout // 60)
+    )
+    return toolkit.redirect_to("user.login",
+                               came_from=toolkit.request.path)
+
+
+# Routeless: it exists only to hang the idle check off ``before_app_request``.
+blueprint = Blueprint("sse_session_policy", __name__)
+
+
+@blueprint.before_app_request
+def _before_app_request():
+    return enforce_idle_timeout()

--- a/ckanext/sse/templates/snippets/password_policy.html
+++ b/ckanext/sse/templates/snippets/password_policy.html
@@ -1,0 +1,15 @@
+{#
+Renders the password policy next to a password field.
+
+The rules come from ``h.sse_password_policy_rules()``, which builds them from
+the same configuration the validator reads. Hardcoding them here would let the
+hint drift from what is actually enforced.
+#}
+<div class="sse-password-policy form-text mb-3">
+  <p class="mb-1">{{ _('Your password must:') }}</p>
+  <ul class="mb-0">
+    {% for rule in h.sse_password_policy_rules() %}
+      <li>{{ rule }}</li>
+    {% endfor %}
+  </ul>
+</div>

--- a/ckanext/sse/templates/user/edit_user_form.html
+++ b/ckanext/sse/templates/user/edit_user_form.html
@@ -1,0 +1,15 @@
+{% ckan_extends %}
+
+{# Two blocks, because CKAN renders one or the other: a sysadmin editing
+   somebody else gets ``sysadmin_password``, everyone else gets
+   ``change_password``. #}
+
+{% block sysadmin_password %}
+  {{ super() }}
+  {% snippet "snippets/password_policy.html" %}
+{% endblock %}
+
+{% block change_password %}
+  {{ super() }}
+  {% snippet "snippets/password_policy.html" %}
+{% endblock %}

--- a/ckanext/sse/templates/user/new_user_form.html
+++ b/ckanext/sse/templates/user/new_user_form.html
@@ -1,0 +1,6 @@
+{% ckan_extends %}
+
+{% block required_core_fields %}
+  {{ super() }}
+  {% snippet "snippets/password_policy.html" %}
+{% endblock %}

--- a/ckanext/sse/templates/user/perform_reset.html
+++ b/ckanext/sse/templates/user/perform_reset.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{# Above the form rather than after it: the reset page has no other content,
+   so a hint underneath the submit button is a hint nobody reads until they
+   have already been rejected. #}
+{% block form %}
+  {% snippet "snippets/password_policy.html" %}
+  {{ super() }}
+{% endblock %}

--- a/ckanext/sse/tests/conftest.py
+++ b/ckanext/sse/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Shared fixtures.
+
+``clean_db`` drops every table and rebuilds CKAN's own, which leaves this
+extension's behind: in production they are created by ``SsePlugin.configure``,
+which has already run by the time a test asks for a clean database. Tests that
+touch them therefore have to put them back, and doing it here rather than in
+each test file keeps the suite independent of the order its files run in.
+"""
+
+import pytest
+
+from ckan.model.meta import engine
+
+from ckanext.sse.model import (
+    FormResponse,
+    PackageAccessRequest,
+    UserPasswordHistory,
+)
+
+EXTENSION_TABLES = (
+    PackageAccessRequest,
+    FormResponse,
+    UserPasswordHistory,
+)
+
+
+@pytest.fixture
+def sse_tables(clean_db):
+    """A clean database with this extension's tables present."""
+    for model in EXTENSION_TABLES:
+        model.__table__.create(engine, checkfirst=True)
+    return engine

--- a/ckanext/sse/tests/test_account_lifecycle.py
+++ b/ckanext/sse/tests/test_account_lifecycle.py
@@ -18,11 +18,19 @@ PASSWORD = "quixotic wobble lantern"
 _serial = itertools.count()
 
 
-def make_user(created_days_ago=90, active_days_ago=None, **kwargs):
-    """A user with its creation and activity timestamps placed in the past."""
+def make_user(created_days_ago=90, active_days_ago=None, capacity="editor",
+              **kwargs):
+    """A dormant user, in scope for the sweep unless told otherwise.
+
+    ``capacity`` puts the account in an organisation, since the sweep only
+    looks at privileged accounts; pass ``None`` for a plain registered user.
+    """
     kwargs.setdefault("email", "lifecycle-%s@example.com" % next(_serial))
     user = factories.User(password=PASSWORD, **kwargs)
     user_obj = model.User.get(user["id"])
+
+    if capacity:
+        add_to_organization(user_obj, capacity)
 
     now = datetime.datetime.utcnow()
     user_obj.created = now - datetime.timedelta(days=created_days_ago)
@@ -32,6 +40,39 @@ def make_user(created_days_ago=90, active_days_ago=None, **kwargs):
     )
     Session.commit()
     return user_obj
+
+
+def add_to_organization(user, capacity="editor"):
+    """Put a user in an organisation without going through the action layer.
+
+    ``factories.Organization`` runs ``organization_create``, which dictizes
+    the new organisation through ``package_search`` -- and this extension's
+    ``package_search`` needs the scheming dataset schema, which is not loaded
+    under ``ckan.plugins = sse``. The rows are what the sweep queries anyway.
+    """
+    org = model.Group(name="org-%s" % next(_serial), title="Org",
+                      type="organization", is_organization=True)
+    org.state = model.State.ACTIVE
+    Session.add(org)
+    Session.flush()
+    Session.add(model.Member(group=org, table_id=user.id, table_name="user",
+                             capacity=capacity, state="active"))
+    Session.commit()
+    return org
+
+
+def add_as_collaborator(user, capacity="editor"):
+    """Make a user a collaborator on a dataset, again without the actions."""
+    package = model.Package(name="pkg-%s" % next(_serial), type="dataset")
+    package.state = model.State.ACTIVE
+    Session.add(package)
+    Session.flush()
+    Session.add(model.PackageMember(
+        package_id=package.id, user_id=user.id, capacity=capacity,
+        modified=datetime.datetime.utcnow(),
+    ))
+    Session.commit()
+    return package
 
 
 @pytest.mark.usefixtures("with_plugins", "sse_tables")
@@ -64,19 +105,19 @@ class TestEligibility:
         Session.commit()
         assert al.is_eligible(user) is False
 
-    def test_sysadmins_are_exempt_by_default(self):
-        """The equivalent of AC-2.3's "Admin Disablement" groups.
-
-        A sweep that disables every administrator during a quiet month
-        leaves nobody able to undo it.
-        """
+    def test_a_dormant_sysadmin_is_eligible(self):
+        """A sysadmin account is the most valuable one on the site."""
         user = make_user(created_days_ago=90, active_days_ago=90,
-                         sysadmin=True)
-        assert al.is_eligible(user) is False
+                         capacity=None, sysadmin=True)
+        assert al.is_eligible(user) is True
 
+    def test_sysadmins_can_be_exempted(self):
+        """The knob for an emergency account that is meant to sit unused."""
+        user = make_user(created_days_ago=90, active_days_ago=90,
+                         capacity=None, sysadmin=True)
         with changed_config("ckanext.sse.inactivity.exempt_sysadmins",
-                            "false"):
-            assert al.is_eligible(user) is True
+                            "true"):
+            assert al.is_eligible(user) is False
 
     def test_named_accounts_can_be_exempted(self):
         user = make_user(created_days_ago=90, active_days_ago=90)
@@ -94,6 +135,75 @@ class TestEligibility:
         user = make_user(created_days_ago=90, active_days_ago=20)
         assert al.is_eligible(user) is False
         assert al.is_eligible(user, idle=10) is True
+
+
+@pytest.mark.usefixtures("with_plugins", "sse_tables")
+class TestScope:
+    """Only accounts carrying privilege are swept."""
+
+    def test_a_plain_registered_account_is_left_alone(self):
+        """Read access to public data is what anonymous visitors have."""
+        user = make_user(created_days_ago=90, active_days_ago=90,
+                         capacity=None)
+        assert al.is_privileged(user) is False
+        assert al.is_eligible(user) is False
+
+    @pytest.mark.parametrize("capacity", ["admin", "editor", "member"])
+    def test_organisation_membership_puts_an_account_in_scope(self, capacity):
+        user = make_user(created_days_ago=90, active_days_ago=90,
+                         capacity=capacity)
+        assert al.is_privileged(user) is True
+        assert al.is_eligible(user) is True
+
+    def test_a_sysadmin_is_in_scope_without_any_organisation(self):
+        user = make_user(created_days_ago=90, active_days_ago=90,
+                         capacity=None, sysadmin=True)
+        assert al.is_privileged(user) is True
+
+    def test_a_dataset_collaborator_is_in_scope(self):
+        """An editor collaborator can change datasets without an org."""
+        user = make_user(created_days_ago=90, active_days_ago=90,
+                         capacity=None)
+        add_as_collaborator(user)
+
+        assert al.is_privileged(user) is True
+        assert al.is_eligible(user) is True
+
+    def test_collaborators_can_be_left_out(self):
+        user = make_user(created_days_ago=90, active_days_ago=90,
+                         capacity=None)
+        add_as_collaborator(user)
+
+        with changed_config(
+                "ckanext.sse.inactivity.include_collaborators", "false"):
+            assert al.is_privileged(user) is False
+
+    def test_which_capacities_count_is_configurable(self):
+        user = make_user(created_days_ago=90, active_days_ago=90,
+                         capacity="member")
+        with changed_config("ckanext.sse.inactivity.capacities",
+                            "admin editor"):
+            assert al.is_privileged(user) is False
+
+    def test_the_scope_can_be_widened_to_every_account(self):
+        user = make_user(created_days_ago=90, active_days_ago=90,
+                         capacity=None)
+        assert al.is_eligible(user) is False
+        with changed_config("ckanext.sse.inactivity.privileged_only",
+                            "false"):
+            assert al.is_eligible(user) is True
+
+    def test_the_sweep_skips_unprivileged_accounts(self):
+        privileged = make_user(created_days_ago=90, active_days_ago=90,
+                               capacity="editor")
+        plain = make_user(created_days_ago=90, active_days_ago=90,
+                          capacity=None)
+
+        disabled = al.disable_inactive_users(dry_run=True)
+
+        names = [record["name"] for record in disabled]
+        assert privileged.name in names
+        assert plain.name not in names
 
 
 @pytest.mark.usefixtures("with_plugins", "sse_tables")

--- a/ckanext/sse/tests/test_account_lifecycle.py
+++ b/ckanext/sse/tests/test_account_lifecycle.py
@@ -1,0 +1,134 @@
+"""Tests for ckanext.sse.account_lifecycle (AC-2.3)."""
+
+import datetime
+import itertools
+
+import pytest
+
+import ckan.model as model
+from ckan.model.meta import Session
+from ckan.tests import factories
+from ckan.tests.helpers import changed_config
+
+from ckanext.sse import account_lifecycle as al
+
+PASSWORD = "quixotic wobble lantern"
+
+
+_serial = itertools.count()
+
+
+def make_user(created_days_ago=90, active_days_ago=None, **kwargs):
+    """A user with its creation and activity timestamps placed in the past."""
+    kwargs.setdefault("email", "lifecycle-%s@example.com" % next(_serial))
+    user = factories.User(password=PASSWORD, **kwargs)
+    user_obj = model.User.get(user["id"])
+
+    now = datetime.datetime.utcnow()
+    user_obj.created = now - datetime.timedelta(days=created_days_ago)
+    user_obj.last_active = (
+        None if active_days_ago is None
+        else now - datetime.timedelta(days=active_days_ago)
+    )
+    Session.commit()
+    return user_obj
+
+
+@pytest.mark.usefixtures("with_plugins", "sse_tables")
+class TestEligibility:
+    def test_an_account_idle_beyond_the_threshold_is_eligible(self):
+        """AC-2.3 e: last logon greater than 45 days."""
+        user = make_user(created_days_ago=90, active_days_ago=46)
+        assert al.is_eligible(user) is True
+
+    def test_an_account_used_recently_is_not(self):
+        user = make_user(created_days_ago=90, active_days_ago=44)
+        assert al.is_eligible(user) is False
+
+    def test_a_new_account_is_not_eligible_however_idle(self):
+        """AC-2.3 e: creation date greater than 30 days.
+
+        The clause exists so an account issued but not yet used is not
+        disabled before its holder has had a chance to use it.
+        """
+        user = make_user(created_days_ago=29, active_days_ago=None)
+        assert al.is_eligible(user) is False
+
+    def test_an_old_account_that_was_never_used_is_eligible(self):
+        user = make_user(created_days_ago=90, active_days_ago=None)
+        assert al.is_eligible(user) is True
+
+    def test_a_disabled_account_is_left_alone(self):
+        user = make_user(created_days_ago=90, active_days_ago=90)
+        user.state = model.State.DELETED
+        Session.commit()
+        assert al.is_eligible(user) is False
+
+    def test_sysadmins_are_exempt_by_default(self):
+        """The equivalent of AC-2.3's "Admin Disablement" groups.
+
+        A sweep that disables every administrator during a quiet month
+        leaves nobody able to undo it.
+        """
+        user = make_user(created_days_ago=90, active_days_ago=90,
+                         sysadmin=True)
+        assert al.is_eligible(user) is False
+
+        with changed_config("ckanext.sse.inactivity.exempt_sysadmins",
+                            "false"):
+            assert al.is_eligible(user) is True
+
+    def test_named_accounts_can_be_exempted(self):
+        user = make_user(created_days_ago=90, active_days_ago=90)
+        with changed_config("ckanext.sse.inactivity.exempt_users",
+                            user.name.upper()):
+            assert al.is_eligible(user) is False
+
+    def test_the_site_user_is_always_exempt(self):
+        """It never signs in, and disabling it breaks the site."""
+        user = make_user(created_days_ago=900, active_days_ago=900)
+        with changed_config("ckan.site_id", user.name):
+            assert al.is_eligible(user) is False
+
+    def test_the_thresholds_are_configurable(self):
+        user = make_user(created_days_ago=90, active_days_ago=20)
+        assert al.is_eligible(user) is False
+        assert al.is_eligible(user, idle=10) is True
+
+
+@pytest.mark.usefixtures("with_plugins", "sse_tables")
+class TestSweep:
+    def test_eligible_accounts_are_disabled(self):
+        stale = make_user(created_days_ago=90, active_days_ago=60)
+        fresh = make_user(created_days_ago=90, active_days_ago=1)
+
+        disabled = al.disable_inactive_users()
+
+        assert [record["name"] for record in disabled] == [stale.name]
+        Session.refresh(stale)
+        Session.refresh(fresh)
+        assert stale.state == model.State.DELETED
+        assert fresh.state == model.State.ACTIVE
+
+    def test_a_dry_run_changes_nothing(self):
+        stale = make_user(created_days_ago=90, active_days_ago=60)
+
+        disabled = al.disable_inactive_users(dry_run=True)
+
+        assert [record["name"] for record in disabled] == [stale.name]
+        Session.refresh(stale)
+        assert stale.state == model.State.ACTIVE
+
+    def test_the_sweep_is_idempotent(self):
+        make_user(created_days_ago=90, active_days_ago=60)
+
+        assert len(al.disable_inactive_users()) == 1
+        assert al.disable_inactive_users() == []
+
+    def test_the_report_carries_the_evidence(self):
+        """AC-2.3's evidence requirement needs the numbers, not just names."""
+        make_user(created_days_ago=90, active_days_ago=60)
+        record = al.disable_inactive_users(dry_run=True)[0]
+        assert record["idle_days"] == 60
+        assert record["last_active"] is not None
+        assert record["created"] is not None

--- a/ckanext/sse/tests/test_login_throttle.py
+++ b/ckanext/sse/tests/test_login_throttle.py
@@ -1,0 +1,203 @@
+"""Tests for ckanext.sse.login_throttle (AC-7).
+
+These need a reachable Redis, since the lockout state lives there. The ini
+used to run them must point ``ckan.redis.url`` at one; ``test-core.ini``
+leaves it at ``localhost``, which is not where Redis is in the Docker
+development environment.
+"""
+
+import pytest
+from flask_login import user_logged_in
+
+import ckan.model as model
+import ckan.plugins.toolkit as toolkit
+from ckan.lib.redis import connect_to_redis
+from ckan.tests import factories
+
+from ckanext.sse import login_throttle as lt
+
+PASSWORD = "quixotic wobble lantern"
+EMAIL = "throttle-test@example.com"
+
+
+@pytest.fixture
+def clean_redis():
+    """The throttle state outlives a test, so clear it either side."""
+    def _clear():
+        redis = connect_to_redis()
+        for pattern in ("sse:login:failures:*", "sse:login:lock:*"):
+            keys = list(redis.scan_iter(match=pattern))
+            if keys:
+                redis.delete(*keys)
+
+    _clear()
+    yield
+    _clear()
+
+
+@pytest.fixture
+def user():
+    return factories.User(password=PASSWORD, email=EMAIL)
+
+
+def login_context(app, login, method="POST"):
+    """A request context that looks like a submission of the login form."""
+    return app.flask_app.test_request_context(
+        "/user/login",
+        method=method,
+        data={"login": login, "password": "wrong"},
+        environ_overrides={"beaker.session": {}},
+    )
+
+
+@pytest.mark.usefixtures("with_plugins", "sse_tables", "clean_redis")
+class TestThrottleKey:
+    def test_a_username_and_an_email_share_one_budget(self, user):
+        """Otherwise the limit is simply doubled by using the other form."""
+        assert lt.throttle_key(user["name"]) == user["name"]
+        assert lt.throttle_key(EMAIL) == user["name"]
+
+    def test_case_does_not_multiply_the_budget(self):
+        assert lt.throttle_key("NoSuchUser") == "nosuchuser"
+
+    def test_an_unknown_login_is_still_counted(self):
+        """Spraying invented names must not get an unlimited budget."""
+        assert lt.throttle_key("no-such-account") == "no-such-account"
+
+    def test_nothing_useful_is_not_a_key(self):
+        assert lt.throttle_key("") is None
+        assert lt.throttle_key("   ") is None
+        assert lt.throttle_key(None) is None
+
+
+@pytest.mark.usefixtures("with_plugins", "sse_tables", "clean_redis")
+class TestLockout:
+    def test_the_account_locks_on_the_sixth_attempt(self, user):
+        """AC-7 a: "a limit of six consecutive invalid logon attempts"."""
+        key = user["name"]
+        for attempt in range(1, lt.DEFAULT_MAX_ATTEMPTS):
+            lt.record_failure(key, model.User.get(key))
+            assert lt.is_locked(key) is False, (
+                "locked after %s attempts" % attempt)
+
+        lt.record_failure(key, model.User.get(key))
+        assert lt.is_locked(key) is True
+
+    def test_the_lock_expires_on_its_own(self, user):
+        """AC-7 b: locked "for 30 minutes"."""
+        key = user["name"]
+        for _unused in range(lt.DEFAULT_MAX_ATTEMPTS):
+            lt.record_failure(key, model.User.get(key))
+
+        remaining = lt.lock_seconds_remaining(key)
+        assert 0 < remaining <= lt.DEFAULT_LOCKOUT_MINUTES * 60
+
+    def test_an_administrator_can_release_the_lock(self, user):
+        """AC-7 b: "or until released by an administrator"."""
+        key = user["name"]
+        for _unused in range(lt.DEFAULT_MAX_ATTEMPTS):
+            lt.record_failure(key, model.User.get(key))
+        assert lt.is_locked(key) is True
+
+        assert lt.clear(key) is True
+        assert lt.is_locked(key) is False
+        assert lt.status(key)["failures"] == 0
+
+    def test_a_successful_login_ends_the_run(self, user):
+        """"Consecutive" means a success resets the count."""
+        key = user["name"]
+        for _unused in range(lt.DEFAULT_MAX_ATTEMPTS - 1):
+            lt.record_failure(key, model.User.get(key))
+        assert lt.status(key)["failures"] == lt.DEFAULT_MAX_ATTEMPTS - 1
+
+        lt.on_user_logged_in(None, user=model.User.get(key))
+        assert lt.status(key)["failures"] == 0
+
+        # And the next failure starts from one again.
+        lt.record_failure(key, model.User.get(key))
+        assert lt.status(key)["failures"] == 1
+
+    @pytest.mark.ckan_config("ckanext.sse.login.max_attempts", "2")
+    def test_the_limit_is_configurable(self, user):
+        key = user["name"]
+        lt.record_failure(key, model.User.get(key))
+        assert lt.is_locked(key) is False
+        lt.record_failure(key, model.User.get(key))
+        assert lt.is_locked(key) is True
+
+    def test_an_unknown_account_can_be_locked_too(self):
+        key = lt.throttle_key("no-such-account")
+        for _unused in range(lt.DEFAULT_MAX_ATTEMPTS):
+            lt.record_failure(key, None)
+        assert lt.is_locked(key) is True
+
+
+@pytest.mark.usefixtures("with_plugins", "sse_tables", "clean_redis")
+class TestHooks:
+    def test_a_failed_login_is_counted(self, app, user):
+        with login_context(app, user["name"]):
+            lt.on_failed_login(user["name"])
+        assert lt.status(user["name"])["failures"] == 1
+
+    def test_a_failed_password_change_is_not_a_logon_attempt(self, app, user):
+        """``failed_login`` also fires for the profile form's old-password
+        check, and mistyping that must not lock the account."""
+        with app.flask_app.test_request_context(
+                "/user/edit/{}".format(user["name"]), method="POST",
+                environ_overrides={"beaker.session": {}}):
+            lt.on_failed_login(user["name"])
+        assert lt.status(user["name"])["failures"] == 0
+
+    def test_a_locked_account_is_refused_before_the_view_runs(self, app, user):
+        key = user["name"]
+        for _unused in range(lt.DEFAULT_MAX_ATTEMPTS):
+            lt.record_failure(key, model.User.get(key))
+
+        with login_context(app, key):
+            response = lt.check_login_lock()
+        assert response is not None
+        assert response.status_code == 302
+        assert "/user/login" in response.headers["Location"]
+
+    def test_an_unlocked_account_is_left_alone(self, app, user):
+        with login_context(app, user["name"]):
+            assert lt.check_login_lock() is None
+
+    def test_a_locked_account_is_refused_by_email_too(self, app, user):
+        key = user["name"]
+        for _unused in range(lt.DEFAULT_MAX_ATTEMPTS):
+            lt.record_failure(key, model.User.get(key))
+
+        with login_context(app, EMAIL):
+            assert lt.check_login_lock() is not None
+
+    def test_other_requests_are_untouched(self, app, user):
+        with app.flask_app.test_request_context(
+                "/dataset", environ_overrides={"beaker.session": {}}):
+            assert lt.check_login_lock() is None
+
+
+@pytest.mark.usefixtures("with_plugins", "sse_tables", "clean_redis")
+def test_a_locked_account_cannot_log_in_over_http(app, user):
+    """The whole control, end to end, through CKAN's own login view."""
+    key = user["name"]
+    for _unused in range(lt.DEFAULT_MAX_ATTEMPTS):
+        lt.record_failure(key, model.User.get(key))
+
+    response = app.post(
+        "/user/login",
+        data={"login": key, "password": PASSWORD},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert "/user/login" in response.headers["Location"]
+
+    # The correct password did not shorten the lockout either.
+    assert lt.is_locked(key) is True
+
+
+@pytest.mark.usefixtures("with_plugins", "sse_tables", "clean_redis")
+def test_the_signal_subscriptions_are_registered():
+    subscriptions = lt.get_subscriptions()
+    assert lt.on_failed_login in subscriptions[toolkit.signals.failed_login]
+    assert lt.on_user_logged_in in subscriptions[user_logged_in]

--- a/ckanext/sse/tests/test_password_policy.py
+++ b/ckanext/sse/tests/test_password_policy.py
@@ -284,7 +284,7 @@ def test_rehash_of_the_same_password_is_recognised():
 # --------------------------------------------------------------------------
 
 
-@pytest.mark.usefixtures("with_plugins", "clean_db")
+@pytest.mark.usefixtures("with_plugins", "sse_tables")
 class TestHistory:
     def test_a_weak_password_cannot_be_registered(self):
         with pytest.raises(toolkit.ValidationError):
@@ -381,7 +381,7 @@ class TestHistory:
 # --------------------------------------------------------------------------
 
 
-@pytest.mark.usefixtures("with_plugins", "clean_db")
+@pytest.mark.usefixtures("with_plugins", "sse_tables")
 class TestRotation:
     def test_a_fresh_password_is_not_expired(self):
         user_obj = model.User.get(make_user()["id"])

--- a/ckanext/sse/tests/test_password_policy.py
+++ b/ckanext/sse/tests/test_password_policy.py
@@ -1,0 +1,363 @@
+"""Tests for ckanext.sse.password_policy.
+
+Every user here is created with an explicit password. ``factories.User``
+defaults to ``faker.password()``, which is ten characters long and so fails
+this policy -- a bare ``factories.User()`` raises ``ValidationError`` while
+this plugin is enabled.
+
+Run with::
+
+    pytest ckanext/sse/tests/test_password_policy.py
+"""
+
+import datetime
+from contextlib import contextmanager
+
+import pytest
+from flask_login import login_user
+from passlib.hash import pbkdf2_sha512
+
+import ckan.model as model
+import ckan.plugins.toolkit as toolkit
+from ckan.common import session
+from ckan.model.meta import Session
+from ckan.tests import factories
+
+from ckanext.sse import password_policy as pp
+from ckanext.sse.model import UserPasswordHistory
+
+STRONG = "Tr0mb0ne-Yak!79"
+ALSO_STRONG = "Zither-Qu1ck!42"
+THIRD_STRONG = "Wombat-Fl!ng62p"
+
+
+EMAIL = "policy-test@example.com"
+
+
+def make_user(password=STRONG, **kwargs):
+    kwargs.setdefault("email", EMAIL)
+    return factories.User(password=password, **kwargs)
+
+
+def set_password(user, password):
+    """Change a password the way the profile form and the API both do."""
+    return toolkit.get_action("user_update")(
+        {"ignore_auth": True, "user": user["name"]},
+        {
+            "id": user["id"],
+            "name": user["name"],
+            # ``user_show`` omits the email for anyone but the user themselves
+            # or a sysadmin, and ``user_update`` requires it.
+            "email": user.get("email") or EMAIL,
+            "password": password,
+        },
+    )
+
+
+@contextmanager
+def request_for(app, url, user=None):
+    """A request context for ``url``, optionally with ``user`` signed in.
+
+    The rotation check is exercised directly rather than by fetching a page,
+    because rendering one needs every extension this portal's templates refer
+    to and the tests run with ``ckan.plugins = sse`` alone. The one place a
+    real page is fetched is the redirect test, where nothing is rendered.
+
+    ``beaker.session`` has to be seeded because CKAN's session interface reads
+    the session straight out of the WSGI environ, where the beaker middleware
+    normally puts it (``BeakerSessionInterface``). Without it Flask hands back
+    a ``NullSession`` that raises on write, and neither ``login_user`` nor the
+    expiry warning can store anything.
+    """
+    with app.flask_app.test_request_context(
+            url, environ_overrides={"beaker.session": {}}):
+        if user is not None:
+            login_user(model.User.get(user["id"]))
+        yield
+
+
+def enforce_for(app, url, user=None):
+    """What the rotation check does to a request for ``url``."""
+    with request_for(app, url, user):
+        return pp.enforce_rotation()
+
+
+def backdate(user_id, days):
+    """Age every recorded password by ``days``.
+
+    All of them, not just the newest: ageing one row only changes which row is
+    the newest, and the rotation window is measured from whichever that is.
+    """
+    for offset, row in enumerate(pp._history(user_id)):
+        row.created_at = (
+            datetime.datetime.utcnow()
+            - datetime.timedelta(days=days + offset)
+        )
+    Session.commit()
+
+
+# --------------------------------------------------------------------------
+# Strength
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "password",
+    [
+        "Tr0mb0ne-Yak!79",
+        "correct horse Battery 9!",   # a space counts as the symbol
+        "Wombat-Fl!ng62p",
+    ],
+)
+def test_accepts_strong_passwords(password):
+    assert pp.check_strength(password) == []
+
+
+@pytest.mark.parametrize(
+    "password",
+    [
+        "Sh0rt!aB",            # under the minimum length
+        "x" * 200 + "A1!",     # over the maximum length
+        "nouppercase1!x",
+        "NOLOWERCASE1!X",
+        "NoDigitsAtAll!x",
+        "NoSymbolsHere12",
+        "Whaaaat-Yak!79",      # three of the same character in a row
+        "wxyz-Tr0mbone!7",     # four sequential characters
+        "Password-Yak!79",     # a banned word, verbatim
+        "P@ssw0rd-Yak!7",      # the same word behind substitutions
+        "Monkey2026!!",        # a common password with characters bolted on
+    ],
+)
+def test_rejects_weak_passwords(password):
+    assert pp.check_strength(password) != []
+
+
+def test_rejects_a_password_containing_the_users_own_details():
+    assert pp.check_strength(
+        "Jbloggs-Tr0mbone!7", identifiers=["jbloggs", "joe@example.com"]
+    ) != []
+
+
+def test_a_common_word_inside_a_longer_passphrase_is_allowed():
+    """The point of the whole-word list: it must not ban English."""
+    assert pp.check_strength("MonkeySawTheSunset!9") == []
+
+
+def test_generated_passwords_satisfy_the_policy():
+    for _unused in range(25):
+        assert pp.check_strength(pp.generate_password()) == []
+
+
+def test_generated_passwords_differ():
+    assert len({pp.generate_password() for _unused in range(10)}) == 10
+
+
+@pytest.mark.ckan_config("ckanext.sse.password.min_length", "16")
+def test_min_length_is_configurable():
+    assert pp.check_strength("Tr0mb0ne-Yak!79") != []
+    assert pp.check_strength("Tr0mb0ne-Yak!79xyQ") == []
+
+
+@pytest.mark.ckan_config("ckanext.sse.password.min_length", "not a number")
+def test_a_broken_setting_falls_back_to_the_default():
+    assert pp.min_length() == pp.DEFAULT_MIN_LENGTH
+
+
+@pytest.mark.ckan_config("ckanext.sse.password.extra_blocklist", "wombat")
+def test_extra_blocklist_words_are_banned():
+    assert pp.check_strength("Wombat-Fl!ng62p") != []
+
+
+def test_policy_rules_are_described():
+    rules = pp.policy_rules()
+    assert any("12" in rule for rule in rules)
+    assert any("90" in rule for rule in rules)
+
+
+@pytest.mark.parametrize(
+    "password, expected",
+    [
+        ("abcd", True),
+        ("4321", True),
+        ("abc", False),
+        ("ab12cd", False),
+        ("Tr0mb0ne-Yak!79", False),
+    ],
+)
+def test_sequence_detection(password, expected):
+    assert pp._has_sequence(password) is expected
+
+
+def test_rehash_of_the_same_password_is_recognised():
+    """A hash upgraded to current pbkdf2 parameters is not a new password."""
+    old = pbkdf2_sha512.using(rounds=1000).hash(STRONG)
+    new = pbkdf2_sha512.hash(STRONG)
+    assert pp._looks_like_rehash(old, new) is True
+    # Two hashes both at current parameters say nothing about the password, so
+    # the safe reading is "changed".
+    assert pp._looks_like_rehash(new, pbkdf2_sha512.hash(ALSO_STRONG)) is False
+
+
+# --------------------------------------------------------------------------
+# History and reuse
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("with_plugins", "clean_db")
+class TestHistory:
+    def test_a_weak_password_cannot_be_registered(self):
+        with pytest.raises(toolkit.ValidationError):
+            make_user(password="password123")
+
+    def test_creating_a_user_records_their_first_password(self):
+        user = make_user()
+        rows = pp._history(user["id"])
+        assert len(rows) == 1
+        assert pbkdf2_sha512.verify(STRONG, rows[0].password_hash)
+
+    def test_the_current_password_cannot_be_set_again(self):
+        user = make_user()
+        with pytest.raises(toolkit.ValidationError):
+            set_password(user, STRONG)
+
+    def test_a_previous_password_cannot_be_set_again(self):
+        user = make_user()
+        set_password(user, ALSO_STRONG)
+        with pytest.raises(toolkit.ValidationError):
+            set_password(user, STRONG)
+
+    def test_a_change_is_recorded(self):
+        user = make_user()
+        set_password(user, ALSO_STRONG)
+        rows = pp._history(user["id"])
+        assert len(rows) == 2
+        assert pbkdf2_sha512.verify(ALSO_STRONG, rows[0].password_hash)
+
+    @pytest.mark.ckan_config("ckanext.sse.password.history_length", "2")
+    def test_the_history_is_pruned_to_the_configured_length(self):
+        user = make_user()
+        for n in range(4):
+            set_password(user, "Quixot%sc-Wobble!%s7" % (chr(98 + n), n))
+        assert len(pp._history(user["id"])) == 2
+
+    @pytest.mark.ckan_config("ckanext.sse.password.history_length", "1")
+    def test_a_password_beyond_the_history_can_be_reused(self):
+        user = make_user()
+        set_password(user, ALSO_STRONG)
+        set_password(user, THIRD_STRONG)
+        # Only the newest is retained, so the original is forgotten.
+        set_password(user, STRONG)
+        assert pp._history(user["id"])[0].password_hash
+
+    def test_an_out_of_band_change_is_reconciled(self):
+        """``ckan user setpass`` writes the model directly."""
+        user = make_user()
+        user_obj = model.User.get(user["id"])
+        original = pp._history(user["id"])[0].id
+
+        user_obj.password = ALSO_STRONG
+        user_obj.save()
+        Session.commit()
+
+        row = pp.sync_history(user_obj)
+        assert row.id != original
+        assert pp.is_reused(ALSO_STRONG, user_obj)
+
+    def test_a_user_with_no_history_is_seeded_rather_than_locked_out(self):
+        user = make_user()
+        Session.query(UserPasswordHistory).filter_by(
+            user_id=user["id"]).delete()
+        Session.commit()
+
+        user_obj = model.User.get(user["id"])
+        row = pp.sync_history(user_obj)
+        assert row is not None
+        assert not pp.is_expired(user_obj)
+
+
+# --------------------------------------------------------------------------
+# Rotation
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("with_plugins", "clean_db")
+class TestRotation:
+    def test_a_fresh_password_is_not_expired(self):
+        user_obj = model.User.get(make_user()["id"])
+        assert pp.is_expired(user_obj) is False
+        assert pp.days_until_expiry(user_obj) == pp.DEFAULT_EXPIRY_DAYS - 1
+
+    def test_a_password_past_the_window_is_expired(self):
+        user = make_user()
+        backdate(user["id"], days=91)
+        assert pp.is_expired(model.User.get(user["id"])) is True
+
+    @pytest.mark.ckan_config("ckanext.sse.password.expiry_days", "0")
+    def test_rotation_can_be_switched_off(self):
+        user = make_user()
+        backdate(user["id"], days=500)
+        user_obj = model.User.get(user["id"])
+        assert pp.days_until_expiry(user_obj) is None
+        assert pp.is_expired(user_obj) is False
+
+    def test_an_expired_password_blocks_a_page(self, app):
+        user = make_user()
+        backdate(user["id"], days=120)
+        response = app.get(
+            "/dataset",
+            extra_environ={"REMOTE_USER": user["name"]},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert "/user/edit/{}".format(user["name"]) in \
+            response.headers["Location"]
+
+    def test_an_expired_password_does_not_block_the_change_form(self, app):
+        user = make_user()
+        backdate(user["id"], days=120)
+        assert enforce_for(app, "/user/edit/" + user["name"], user) is None
+
+    def test_an_expired_password_does_not_block_the_api(self, app):
+        user = make_user()
+        backdate(user["id"], days=120)
+        assert enforce_for(app, "/api/3/action/status_show", user) is None
+
+    def test_an_expired_password_does_not_block_logout(self, app):
+        user = make_user()
+        backdate(user["id"], days=120)
+        assert enforce_for(app, "/user/_logout", user) is None
+
+    def test_an_expired_password_does_not_block_a_password_reset(self, app):
+        user = make_user()
+        backdate(user["id"], days=120)
+        assert enforce_for(app, "/user/reset", user) is None
+
+    def test_a_valid_password_is_not_blocked(self, app):
+        user = make_user()
+        assert enforce_for(app, "/dataset", user) is None
+
+    def test_changing_the_password_lifts_the_block(self, app):
+        user = make_user()
+        backdate(user["id"], days=120)
+        set_password(user, ALSO_STRONG)
+        assert enforce_for(app, "/dataset", user) is None
+
+    def test_an_anonymous_request_is_untouched(self, app):
+        assert enforce_for(app, "/dataset") is None
+
+    def test_an_approaching_expiry_warns_once(self, app):
+        user = make_user()
+        backdate(user["id"], days=pp.DEFAULT_EXPIRY_DAYS - 3)
+        with request_for(app, "/dataset", user):
+            assert pp.enforce_rotation() is None
+            assert session.get(pp._WARNED_SESSION_KEY)
+            # Read the flashes out of the session rather than through
+            # ``get_flashed_messages``, which caches its result for the rest
+            # of the request and so cannot show a second flash arriving.
+            assert len(session["_flashes"]) == 1
+            assert "expires in" in session["_flashes"][0][1]
+
+            # Same session, so the second look says nothing more.
+            pp.enforce_rotation()
+            assert len(session["_flashes"]) == 1

--- a/ckanext/sse/tests/test_password_policy.py
+++ b/ckanext/sse/tests/test_password_policy.py
@@ -22,6 +22,7 @@ import ckan.plugins.toolkit as toolkit
 from ckan.common import session
 from ckan.model.meta import Session
 from ckan.tests import factories
+from ckan.tests.helpers import changed_config
 
 from ckanext.sse import password_policy as pp
 from ckanext.sse.model import UserPasswordHistory
@@ -105,7 +106,8 @@ def backdate(user_id, days):
     "password",
     [
         "Tr0mb0ne-Yak!79",
-        "correct horse Battery 9!",   # a space counts as the symbol
+        "correct horse Battery staple",   # the "three random word" approach
+        "wombat lantern rivet",           # lowercase, no digits, no symbols
         "Wombat-Fl!ng62p",
     ],
 )
@@ -118,12 +120,9 @@ def test_accepts_strong_passwords(password):
     [
         "Sh0rt!aB",            # under the minimum length
         "x" * 200 + "A1!",     # over the maximum length
-        "nouppercase1!x",
-        "NOLOWERCASE1!X",
-        "NoDigitsAtAll!x",
-        "NoSymbolsHere12",
-        "Whaaaat-Yak!79",      # three of the same character in a row
-        "wxyz-Tr0mbone!7",     # four sequential characters
+        "Whaaaaat-Yak!79",     # five of the same character in a row
+        "wxyz-Tr0mbone!7",     # four sequential letters
+        "Trombone-123-Yak",    # three sequential digits
         "Password-Yak!79",     # a banned word, verbatim
         "P@ssw0rd-Yak!7",      # the same word behind substitutions
         "Monkey2026!!",        # a common password with characters bolted on
@@ -131,6 +130,22 @@ def test_accepts_strong_passwords(password):
 )
 def test_rejects_weak_passwords(password):
     assert pp.check_strength(password) != []
+
+
+def test_no_character_classes_are_demanded_by_default():
+    """The standard asks for passphrases, so complexity rules are off.
+
+    A rule demanding an uppercase, a digit and a symbol works directly
+    against the "three random word" approach the standard recommends.
+    """
+    assert pp.check_strength("wombat lantern rivet") == []
+
+
+@pytest.mark.ckan_config(
+    "ckanext.sse.password.require_character_classes", "true")
+def test_character_classes_can_be_demanded():
+    assert pp.check_strength("wombat lantern rivet") != []
+    assert pp.check_strength("Wombat-Fl!ng62p") == []
 
 
 def test_rejects_a_password_containing_the_users_own_details():
@@ -146,11 +161,25 @@ def test_a_common_word_inside_a_longer_passphrase_is_allowed():
 
 def test_generated_passwords_satisfy_the_policy():
     for _unused in range(25):
-        assert pp.check_strength(pp.generate_password()) == []
+        assert pp.check_strength(pp.generate_password(),
+                                 privileged=True) == []
+
+
+def test_generated_passwords_meet_the_service_account_length():
+    assert len(pp.generate_password()) >= pp.DEFAULT_SERVICE_ACCOUNT_LENGTH
 
 
 def test_generated_passwords_differ():
     assert len({pp.generate_password() for _unused in range(10)}) == 10
+
+
+def test_administration_accounts_need_a_longer_passphrase():
+    """IA-5.1 g: 12 characters for users, 15 for administration accounts."""
+    twelve = "wombat rivet"
+    assert len(twelve) == 12
+    assert pp.check_strength(twelve) == []
+    assert pp.check_strength(twelve, privileged=True) != []
+    assert pp.check_strength("wombat lantern rivet", privileged=True) == []
 
 
 @pytest.mark.ckan_config("ckanext.sse.password.min_length", "16")
@@ -169,24 +198,75 @@ def test_extra_blocklist_words_are_banned():
     assert pp.check_strength("Wombat-Fl!ng62p") != []
 
 
+def test_a_maintained_blocklist_file_is_read(tmp_path):
+    """IA-5.1 a and b: the list has to be updatable without a release."""
+    listing = tmp_path / "compromised.txt"
+    listing.write_text("# a comment\nhippopotamus\n\n")
+    with changed_config("ckanext.sse.password.blocklist_file", str(listing)):
+        assert pp.check_strength("hippopotamus") != []
+        assert pp.check_strength("hippopotamus rivet lantern") == []
+
+        # Replacing the file is picked up without a restart.
+        listing.write_text("# a comment\n")
+        assert pp.check_strength("hippopotamus") == []
+
+
 def test_policy_rules_are_described():
-    rules = pp.policy_rules()
+    rules = pp.policy_rules(privileged=False)
     assert any("12" in rule for rule in rules)
-    assert any("90" in rule for rule in rules)
+    assert any(str(pp.DEFAULT_EXPIRY_DAYS) in rule for rule in rules)
+    assert any("passphrase" in rule for rule in rules)
+
+    privileged = pp.policy_rules(privileged=True)
+    assert any("15" in rule for rule in privileged)
+    assert any(str(pp.DEFAULT_PRIVILEGED_EXPIRY_DAYS) in rule
+               for rule in privileged)
 
 
 @pytest.mark.parametrize(
     "password, expected",
     [
-        ("abcd", True),
-        ("4321", True),
-        ("abc", False),
+        ("abcd", True),        # four sequential letters
+        ("abc", False),        # three is allowed
+        ("123", True),         # three sequential digits is not
+        ("4321", True),        # descending too
+        ("12", False),
         ("ab12cd", False),
+        ("Summer2024 rivet", False),
         ("Tr0mb0ne-Yak!79", False),
     ],
 )
 def test_sequence_detection(password, expected):
     assert pp._has_sequence(password) is expected
+
+
+@pytest.mark.parametrize(
+    "password, expected",
+    [
+        ("aaaa", False),       # four repeats is allowed
+        ("aaaaa", True),       # five is not
+        ("Whaaaat", False),
+        ("Whaaaaat", True),
+    ],
+)
+def test_repeat_detection(password, expected):
+    assert pp._has_repeat(password) is expected
+
+
+def test_incremental_variants_reconstruct_the_previous_password():
+    variants = pp.incremental_variants("Welcome101")
+    assert "Welcome100" in variants
+    assert "Welcome102" in variants
+    assert "Welcome" in variants          # the digits dropped entirely
+    assert "Welcome101" not in variants   # itself is not a variant
+
+    # The last run of digits anywhere, not only a trailing one.
+    assert "Summer2023!" in pp.incremental_variants("Summer2024!")
+
+    # Zero padding is preserved as well as dropped, since the width can change.
+    assert "Welcome09" in pp.incremental_variants("Welcome10")
+
+    assert pp.incremental_variants("no digits here") == []
 
 
 def test_rehash_of_the_same_password_is_recognised():
@@ -275,6 +355,26 @@ class TestHistory:
         assert row is not None
         assert not pp.is_expired(user_obj)
 
+    def test_the_last_eight_passwords_are_retained_by_default(self):
+        """IA-5.1: "Not be the same as any of the last 8 passwords"."""
+        user = make_user()
+        for n in range(10):
+            set_password(user, "quixotic wobble %s" % chr(98 + n))
+        assert len(pp._history(user["id"])) == 8
+        assert pp.history_length() == 8
+
+    def test_a_password_cannot_be_bumped_by_a_number(self):
+        """IA-5.1: not "changed incrementally, e.g. Welcome100, Welcome101"."""
+        user = make_user(password="quixotic wobble 100")
+        with pytest.raises(toolkit.ValidationError) as raised:
+            set_password(user, "quixotic wobble 101")
+        assert "number changed" in str(raised.value.error_dict)
+
+    def test_an_unrelated_password_with_a_number_is_accepted(self):
+        user = make_user(password="quixotic wobble 100")
+        set_password(user, "lantern rivet 42")
+        assert len(pp._history(user["id"])) == 2
+
 
 # --------------------------------------------------------------------------
 # Rotation
@@ -289,21 +389,35 @@ class TestRotation:
         assert pp.days_until_expiry(user_obj) == pp.DEFAULT_EXPIRY_DAYS - 1
 
     def test_a_password_past_the_window_is_expired(self):
+        """IA-5 f: 365 days for a non-privileged user."""
         user = make_user()
-        backdate(user["id"], days=91)
+        backdate(user["id"], days=pp.DEFAULT_EXPIRY_DAYS - 1)
+        assert pp.is_expired(model.User.get(user["id"])) is False
+        backdate(user["id"], days=pp.DEFAULT_EXPIRY_DAYS + 1)
         assert pp.is_expired(model.User.get(user["id"])) is True
+
+    def test_a_privileged_password_expires_sooner(self):
+        """IA-5 f: 60 days for a privileged user."""
+        user = make_user(sysadmin=True)
+        user_obj = model.User.get(user["id"])
+        assert pp.is_privileged(user_obj) is True
+
+        backdate(user["id"], days=pp.DEFAULT_PRIVILEGED_EXPIRY_DAYS - 1)
+        assert pp.is_expired(user_obj) is False
+        backdate(user["id"], days=pp.DEFAULT_PRIVILEGED_EXPIRY_DAYS + 1)
+        assert pp.is_expired(user_obj) is True
 
     @pytest.mark.ckan_config("ckanext.sse.password.expiry_days", "0")
     def test_rotation_can_be_switched_off(self):
         user = make_user()
-        backdate(user["id"], days=500)
+        backdate(user["id"], days=5000)
         user_obj = model.User.get(user["id"])
         assert pp.days_until_expiry(user_obj) is None
         assert pp.is_expired(user_obj) is False
 
     def test_an_expired_password_blocks_a_page(self, app):
         user = make_user()
-        backdate(user["id"], days=120)
+        backdate(user["id"], days=pp.DEFAULT_EXPIRY_DAYS + 30)
         response = app.get(
             "/dataset",
             extra_environ={"REMOTE_USER": user["name"]},
@@ -315,22 +429,22 @@ class TestRotation:
 
     def test_an_expired_password_does_not_block_the_change_form(self, app):
         user = make_user()
-        backdate(user["id"], days=120)
+        backdate(user["id"], days=pp.DEFAULT_EXPIRY_DAYS + 30)
         assert enforce_for(app, "/user/edit/" + user["name"], user) is None
 
     def test_an_expired_password_does_not_block_the_api(self, app):
         user = make_user()
-        backdate(user["id"], days=120)
+        backdate(user["id"], days=pp.DEFAULT_EXPIRY_DAYS + 30)
         assert enforce_for(app, "/api/3/action/status_show", user) is None
 
     def test_an_expired_password_does_not_block_logout(self, app):
         user = make_user()
-        backdate(user["id"], days=120)
+        backdate(user["id"], days=pp.DEFAULT_EXPIRY_DAYS + 30)
         assert enforce_for(app, "/user/_logout", user) is None
 
     def test_an_expired_password_does_not_block_a_password_reset(self, app):
         user = make_user()
-        backdate(user["id"], days=120)
+        backdate(user["id"], days=pp.DEFAULT_EXPIRY_DAYS + 30)
         assert enforce_for(app, "/user/reset", user) is None
 
     def test_a_valid_password_is_not_blocked(self, app):
@@ -339,7 +453,7 @@ class TestRotation:
 
     def test_changing_the_password_lifts_the_block(self, app):
         user = make_user()
-        backdate(user["id"], days=120)
+        backdate(user["id"], days=pp.DEFAULT_EXPIRY_DAYS + 30)
         set_password(user, ALSO_STRONG)
         assert enforce_for(app, "/dataset", user) is None
 

--- a/ckanext/sse/tests/test_plugin.py
+++ b/ckanext/sse/tests/test_plugin.py
@@ -47,7 +47,9 @@ To temporary patch the CKAN configuration for the duration of a test you can use
     def test_some_action():
         pass
 """
-import ckanext.sse.plugin as plugin
+import pytest
+
+from ckan.plugins import plugin_loaded
 
 
 @pytest.mark.ckan_config("ckan.plugins", "sse")

--- a/ckanext/sse/tests/test_session_policy.py
+++ b/ckanext/sse/tests/test_session_policy.py
@@ -1,0 +1,103 @@
+"""Tests for ckanext.sse.session_policy (AC-2.5, AC-11)."""
+
+import time
+from contextlib import contextmanager
+
+import pytest
+from flask_login import login_user
+
+import ckan.model as model
+from ckan.common import session
+from ckan.tests import factories
+from ckan.tests.helpers import changed_config
+
+from ckanext.sse import session_policy as sp
+
+PASSWORD = "quixotic wobble lantern"
+
+
+@contextmanager
+def request_for(app, url, user=None, last_seen=None):
+    """A request context, optionally signed in and with an activity stamp.
+
+    ``beaker.session`` is seeded because CKAN's session interface reads the
+    session out of the WSGI environ, where the beaker middleware normally puts
+    it; without it Flask hands back a ``NullSession`` that raises on write.
+    """
+    with app.flask_app.test_request_context(
+            url, environ_overrides={"beaker.session": {}}):
+        if user is not None:
+            login_user(model.User.get(user["id"]))
+        if last_seen is not None:
+            session[sp.SESSION_KEY] = last_seen
+        yield
+
+
+@pytest.fixture
+def user():
+    return factories.User(password=PASSWORD,
+                          email="session-test@example.com")
+
+
+@pytest.mark.usefixtures("with_plugins", "sse_tables")
+class TestIdleTimeout:
+    def test_an_idle_session_is_ended(self, app, user):
+        """AC-11 a: a lock after 15 minutes of inactivity."""
+        stale = int(time.time()) - (sp.DEFAULT_IDLE_TIMEOUT_MINUTES * 60) - 1
+        with request_for(app, "/dataset", user, last_seen=stale):
+            response = sp.enforce_idle_timeout()
+            assert response is not None
+            assert response.status_code == 302
+            assert "/user/login" in response.headers["Location"]
+
+    def test_an_active_session_is_left_alone(self, app, user):
+        recent = int(time.time()) - 60
+        with request_for(app, "/dataset", user, last_seen=recent):
+            assert sp.enforce_idle_timeout() is None
+
+    def test_the_stamp_is_set_on_a_first_request(self, app, user):
+        with request_for(app, "/dataset", user):
+            assert sp.enforce_idle_timeout() is None
+            assert session.get(sp.SESSION_KEY)
+
+    def test_the_stamp_is_not_rewritten_on_every_request(self, app, user):
+        """Beaker sends a Set-Cookie whenever the session changes."""
+        recent = int(time.time()) - 5
+        with request_for(app, "/dataset", user, last_seen=recent):
+            sp.enforce_idle_timeout()
+            assert session[sp.SESSION_KEY] == recent
+
+    def test_the_stamp_is_refreshed_once_it_is_stale_enough(self, app, user):
+        older = int(time.time()) - sp.STAMP_INTERVAL_SECONDS - 5
+        with request_for(app, "/dataset", user, last_seen=older):
+            sp.enforce_idle_timeout()
+            assert session[sp.SESSION_KEY] > older
+
+    def test_anonymous_requests_are_untouched(self, app):
+        with request_for(app, "/dataset"):
+            assert sp.enforce_idle_timeout() is None
+
+    def test_the_api_is_exempt(self, app, user):
+        """A client presenting a token is not idle at a screen."""
+        stale = int(time.time()) - (sp.DEFAULT_IDLE_TIMEOUT_MINUTES * 60) - 1
+        with request_for(app, "/api/3/action/status_show", user,
+                         last_seen=stale):
+            assert sp.enforce_idle_timeout() is None
+
+    def test_the_timeout_can_be_switched_off(self, app, user):
+        stale = int(time.time()) - 86400
+        with changed_config("ckanext.sse.session.idle_timeout_minutes", "0"):
+            with request_for(app, "/dataset", user, last_seen=stale):
+                assert sp.enforce_idle_timeout() is None
+
+    def test_the_timeout_is_configurable(self, app, user):
+        stale = int(time.time()) - 120
+        with changed_config("ckanext.sse.session.idle_timeout_minutes", "1"):
+            with request_for(app, "/dataset", user, last_seen=stale):
+                assert sp.enforce_idle_timeout() is not None
+
+    def test_a_broken_setting_falls_back_to_the_default(self):
+        with changed_config("ckanext.sse.session.idle_timeout_minutes",
+                            "not a number"):
+            assert sp.idle_timeout_seconds() == \
+                sp.DEFAULT_IDLE_TIMEOUT_MINUTES * 60


### PR DESCRIPTION
Closes datopian/client-sse-networks-shared#328 (SR0007564, IA-5).

Implements SSE's *Standard for Identification and Authentication* (IA-5, IA-5.1)
and three controls from the *Standard for Access Control* (AC-7, AC-2.3,
AC-2.5/AC-11), as far as a CKAN portal can. CKAN's only password rule is "8
characters or longer" and it has no account lockout, no dormant-account
disablement and no idle timeout at all.

The first two commits were written before the standard was available and used
best-practice defaults; the third replaces those with what the standard
actually requires. Reviewing the diff as a whole is easier than commit by
commit.

## Clause by clause

| IA-5 / IA-5.1 | Where |
| --- | --- |
| 12 characters or more, 15 for administration accounts | `check_strength` |
| Not on a list of common/expected/compromised passwords | `_blocklist`, `blocklist_file` |
| Not contain any part of the username | `check_strength` |
| Not be a single dictionary word | blocklist (partial — see below) |
| Not more than 4 repeating characters or digits | `_has_repeat` |
| No ascending or descending number sequences | `_has_sequence` |
| Not changed incrementally (`Welcome100`, `Welcome101`) | `is_incremental` |
| Not the same as any of the last 8 passwords | `is_reused` |
| New password on account recovery | CKAN's reset flow |
| Stored with an approved salted hash | CKAN's pbkdf2-sha512 |
| Rotation: 365 days, 60 for privileged | `expires_at` |

"Privileged" is read as a CKAN sysadmin. Organisation admins administer a
publisher's datasets rather than the system, so they are held to the ordinary
user rules.

## Points worth a reviewer's attention

- **There is no character-class requirement, deliberately.** The standard
  prefers passphrases and endorses the "three random word" approach. Requiring
  an uppercase, a digit and a symbol works directly against that — the earlier
  draft rejected `correct horse battery staple` while `P@ssw0rd1` would have
  passed on classes alone. Every other rule still applies to a passphrase, and
  `require_character_classes` turns one back on if wanted.

- **"Not changed incrementally" needed reconstructing, not comparing.** Only
  hashes of previous passwords are stored, so the previous password cannot be
  read. The candidates it *would* have been are rebuilt from the new password —
  the last run of digits anywhere in it, varied either side and dropped
  entirely, zero-padded and bare — and each is verified against the stored
  hash. Checked against the current password alone, matching the standard's
  "on password change" wording and keeping it to about a dozen verifications
  (15ms each, measured) instead of a dozen per retained hash.

- **The blocklist has to be maintainable.** IA-5.1 a and b call for a list
  "updated continually", which a list in the source cannot be.
  `blocklist_file` points at a file of one word per line, re-read on mtime
  change so replacing it needs no restart. Its entries join the *whole-password*
  list rather than the substring list — a compromised-password corpus is full of
  ordinary English words, and banning those as substrings would ban the
  passphrases the standard asks for.

- **`IAuthenticator.identify` does not work for the rotation block.**
  `identify_user()` stops calling authenticators as soon as one leaves a user
  identified, and `ckanext-noanonaccess` is ahead of this extension in
  `ckan.plugins`, so for an authenticated user — the only kind the check
  applies to — `identify()` here is never reached. Measured, not assumed: the
  redirect silently did nothing until it moved to a `before_app_request`
  handler on a routeless blueprint.

- **The action API is exempt.** A token is a separate credential with its own
  lifecycle, its holder may be an integration whose owner never signs in, and
  answering a JSON call with a redirect to an HTML form breaks the client
  rather than protecting anything. Flagging in case the audit wants otherwise.

- **No migration, and nobody is locked out on deploy day.** There is no
  "password last changed" column, and some paths change a password without
  going through an action (`ckan user setpass` assigns `user.password` and
  commits). The history is reconciled against the live hash whenever it is
  read, which also seeds the table: each user's first request starts a full
  window for them. CKAN's rehash-on-login is detected narrowly so it cannot
  silently extend that window.

- **`user_login` had to change.** It generated the throwaway password for
  frontend-created accounts from `random.choice` over letters and digits at
  length 10 — rejected by the new policy, so it would have broken the frontend
  auth bridge. Now `generate_password()`, which draws from `secrets` (`random`
  is a Mersenne Twister, recoverable from a handful of samples), validates
  candidates against the live policy rather than assembling one rule by rule,
  and produces 20 characters to match the standard's service-account length.

## Not enforced here

Listed so the gap is visible rather than assumed covered: TLS-only transmission
(IA-5.1 c, an ingress concern); admin accounts not sharing a password with the
holder's AD account (f); passphrases not reused outside SSE; and "not a single
dictionary word", which is only as good as the configured blocklist file — the
built-in list covers common passwords, not the dictionary.

## Access control (AC-7, AC-2.3, AC-2.5/AC-11)

**AC-7, account lockout.** Six consecutive failed sign-ins lock the account for
30 minutes. The mechanism follows `ckanext-security` — two Redis keys per
account, a counter and a lock, each with its own expiry, so the expiring key
*is* the timer and `INCR` stays atomic across workers.

The hook differs, for a concrete reason worth reviewing. `ckanext-security`
counts from `IAuthenticator.authenticate()`, which calls
`default_authenticate()` itself and returns `None` on bad credentials;
`ckan_authenticator` reads `None` as "no opinion" and falls through to
`default_authenticate()` **a second time**, so every failed login is
authenticated twice and emits `failed_login` twice — which this deployment
records in its audit trail. Counting from the signal instead, and blocking from
a `before_app_request` handler ahead of the login view, keeps one attempt to one
event and means a correct password presented during a lockout cannot shorten it.

`failed_login` also fires for the profile form's old-password check, so
receivers are filtered to the login endpoint — mistyping your current password
while changing it must not lock the account.

Keyed on the account (username and email resolve to one budget); an attempt
against a login matching no account is counted under what was typed. The known
cost is that a third party can lock a named account out by failing six times;
that is inherent in account lockout, and the expiry bounds it. **Redis is
required**, and its absence fails *open* with an error logged — a cache outage
locking every user out of the portal is the worse failure.

Lockouts are audited as `user_lockout` and emailed to the account holder.
`ckan sse login-status` and `ckan sse unlock-login` are the "or until released
by an administrator" half.

**AC-2.3, dormant accounts.** Idle beyond 45 days and older than 30 days →
CKAN's `deleted` state, restorable by a sysadmin. Idle is measured from
`user.last_active`, which CKAN stamps on every authenticated request, so an
account making daily API calls counts as in use; never-active accounts fall back
to their creation date.

**Only privileged accounts are swept** — sysadmins, organisation
members/editors/admins, and dataset collaborators. On a public data portal most
registered accounts are consumers with no organisation, whose access is read
access to public data that the portal already offers anonymously; disabling
those churns ordinary users without retiring any access. Organisation *members*
are in scope despite the read-only capacity, because membership carries access
to that organisation's private datasets. Collaborators are in scope because an
editor collaborator can change datasets without belonging to any organisation.
`user_group` membership does not count — this portal uses those to share private
datasets, and they carry no write access. `privileged_only = false` reverts to
sweeping everything.

Sysadmins are **in** scope (`exempt_sysadmins` now defaults to false): a dormant
sysadmin account is the most valuable one on the site. The recovery path if a
sweep ever disables the last active one is `ckan sysadmin add` from a shell,
outside the web session a sweep can affect. The site user is always exempt.

**This one needs a cron entry or CronJob to satisfy "automatically disable"** —
there is no scheduler in a CKAN extension. `ckan sse disable-inactive-users`,
idempotent, with `--dry-run`.

**AC-2.5/AC-11, idle timeout.** 15 minutes idle ends a signed-in session.
Anonymous browsing and the API are unaffected. The activity stamp is rewritten
at most once a minute, so this does not add a session write per request.

All three run from `before_app_request` handlers, and Flask runs those in
blueprint registration order, so the order in `get_blueprint()` is load-bearing
and commented: lockout, then idle timeout, then password rotation — otherwise a
timed-out user is sent to a form that is about to sign them out.

## Settings

All defaults come from the standard; every one is overridable.

| Setting | Default |
| --- | --- |
| `ckanext.sse.password.min_length` | `12` |
| `ckanext.sse.password.privileged_min_length` | `15` |
| `ckanext.sse.password.max_length` | `128` |
| `ckanext.sse.password.history_length` | `8` |
| `ckanext.sse.password.expiry_days` | `365` |
| `ckanext.sse.password.privileged_expiry_days` | `60` |
| `ckanext.sse.password.warn_days` | `14` |
| `ckanext.sse.password.max_repeat` | `4` |
| `ckanext.sse.password.max_digit_sequence` | `2` |
| `ckanext.sse.password.max_letter_sequence` | `3` |
| `ckanext.sse.password.increment_window` | `3` |
| `ckanext.sse.password.require_character_classes` | `false` |
| `ckanext.sse.password.blocklist_file` | – |
| `ckanext.sse.password.extra_blocklist` | – |
| `ckanext.sse.login.max_attempts` | `6` |
| `ckanext.sse.login.lockout_minutes` | `30` |
| `ckanext.sse.login.attempt_window_minutes` | `30` |
| `ckanext.sse.login.notify_lockout` | `true` |
| `ckanext.sse.inactivity.idle_days` | `45` |
| `ckanext.sse.inactivity.min_account_age_days` | `30` |
| `ckanext.sse.inactivity.privileged_only` | `true` |
| `ckanext.sse.inactivity.capacities` | `admin editor member` |
| `ckanext.sse.inactivity.include_collaborators` | `true` |
| `ckanext.sse.inactivity.exempt_sysadmins` | `false` |
| `ckanext.sse.inactivity.exempt_users` | – |
| `ckanext.sse.session.idle_timeout_minutes` | `15` |

No plugin change needed: this is all part of the existing `sse` plugin, so
`CKAN__PLUGINS` is untouched. Two deployment steps are required, though: a
reachable `ckan.redis.url` for the lockout state, and a scheduled
`ckan sse disable-inactive-users`. Worth deciding before merge whether to ship a
compromised-password corpus at `blocklist_file`, which is what makes IA-5.1 a
and b fully satisfied.

## Testing

117 tests, all passing.

- `test_password_policy.py` — each strength rule against the standard's own
  examples, the generator, history recording and pruning at 8, reuse rejection
  through `user_update`, incremental-change detection, blocklist-file
  reloading, out-of-band reconciliation, rehash detection, and the rotation
  block including its allowlist, the API exemption and the privileged window.
- `test_login_throttle.py` — the sixth attempt locking, expiry, administrator
  release, a success resetting the run, username/email sharing one budget,
  unknown accounts still counted, the profile-form exclusion, and the whole
  control end to end through CKAN's own login view.
- `test_account_lifecycle.py` — each AC-2.3 clause, the privilege scoping
  (plain account skipped; org member/editor/admin, collaborator and sysadmin
  swept; each toggle), the exemptions, dry-run and idempotence.
- `test_session_policy.py` — timeout, stamp refresh throttling, API and
  anonymous exemptions, configurability.

Also driven end-to-end against a local dev CKAN over HTTP: six bad sign-ins
lock the account, the correct password is then refused, `ckan sse unlock-login`
releases it and the same password works; an expired password redirects off
every page and access returns the moment it is changed; and a dormant
organisation member is swept while an identically dormant account with no
membership is left alone.

Note for future tests: `clean_db` drops this extension's tables and does not
rebuild them, so DB tests use the new `sse_tables` fixture. `factories.User`
also defaults to a ten-character `faker.password()`, which the policy rejects,
so tests must pass a password.

## Follow-ups

- Decide on a `blocklist_file` corpus to ship or mount.
- Schedule `ckan sse disable-inactive-users` (cron or CronJob).
- Confirm `ckan.redis.url` is set in every environment.
- If the Next.js frontend has its own signup or change-password UI, its
  client-side hints now disagree with server enforcement (separate repo).
- The frontend auth bridge (`user_login`) signs a user in with a shared client
  secret and an email address, no password, so AC-7 does not cover it. Guessing
  that secret is a different risk and needs its own look.

